### PR TITLE
Removing all use of v62.

### DIFF
--- a/Dec.v
+++ b/Dec.v
@@ -72,27 +72,27 @@ Lemma dans_tq_imp :
  dans x (tq f E) -> dans x E /\ f x.
 intros x f.
 simple induction E.
-replace (tq f empty) with empty; auto with v62.
+replace (tq f empty) with empty; auto.
 intro.
-apply (dans_empty_imp_P x); auto with v62.
+apply (dans_empty_imp_P x); auto.
 intros a b H.
 replace (tq f (add a b)) with
  match Pdec f a return Ensf with
  | left fa => add a (tq f b)
  | right nfa => tq f b
- end; auto with v62.
+ end; auto.
 elim (Pdec f a).
 intros a0 H0.
 cut (a = x :>Elt \/ dans x (tq f b)).
-2: apply dans_add; auto with v62.
+2: apply dans_add; auto.
 intro H1; elim H1; clear H1.
-intro H1; rewrite <- H1; auto with v62.
+intro H1; rewrite <- H1; auto.
 intro.
-cut (dans x b /\ f x); auto with v62.
-intro H2; elim H2; auto with v62.
+cut (dans x b /\ f x); auto.
+intro H2; elim H2; auto.
 intros.
-cut (dans x b /\ f x); auto with v62.
-intro H1; elim H1; auto with v62.
+cut (dans x b /\ f x); auto.
+intro H1; elim H1; auto.
 Qed.
 
 (*  									*)
@@ -106,30 +106,30 @@ Lemma imp_dans_tq :
 intros x f.
 simple induction E.
 intro.
-apply (dans_empty_imp_P x); auto with v62.
+apply (dans_empty_imp_P x); auto.
 intros a b H H0 x0.
 replace (tq f (add a b)) with
  match Pdec f a return Ensf with
  | left fa => add a (tq f b)
  | right nfa => tq f b
- end; auto with v62.
+ end; auto.
 elim (Pdec f a).
 
 intro.
 cut (a = x :>Elt \/ dans x b). 
-2: apply dans_add; auto with v62.
+2: apply dans_add; auto.
 intro H1; elim H1; clear H1.
-intro H1; rewrite H1; auto with v62.
-auto with v62.
+intro H1; rewrite H1; auto.
+auto.
 
 intro.
 cut (a = x :>Elt \/ dans x b). 
-2: apply dans_add; auto with v62.
+2: apply dans_add; auto.
 intro H1; elim H1; clear H1.
 intro.
-absurd (f a); auto with v62.
-rewrite H1; auto with v62.
-auto with v62.
+absurd (f a); auto.
+rewrite H1; auto.
+auto.
 Qed.
 
 (*									*)
@@ -140,7 +140,7 @@ Qed.
 Lemma inclus_tq : forall (f : Elt -> Prop) (a : Ensf), inclus (tq f a) a.
 unfold inclus in |- *.
 intros.
-cut (dans x a /\ f x); auto with v62.
-2: apply dans_tq_imp; auto with v62.
-intro H0; elim H0; auto with v62.
+cut (dans x a /\ f x); auto.
+2: apply dans_tq_imp; auto.
+intro H0; elim H0; auto.
 Qed.

--- a/Ensf_couple.v
+++ b/Ensf_couple.v
@@ -76,17 +76,17 @@ Lemma equal_couple :
  forall x y z t : Elt,
  couple x y = couple z t :>Elt -> x = z :>Elt /\ y = t :>Elt.
 intros x y z t H.
-injection H; auto with v62.
+injection H; auto.
 Qed.
 
 Lemma couple_couple_inv1 :
  forall a b c d : Elt, couple a c = couple b d :>Elt -> a = b :>Elt.
 intros a b c d H.
-injection H; auto with v62.
+injection H; auto.
 Qed.
  
 Lemma couple_couple_inv2 :
  forall a b c d : Elt, couple a c = couple b d :>Elt -> c = d :>Elt.
 intros a b c d H.
-injection H; auto with v62.
+injection H; auto.
 Qed.

--- a/Ensf_dans.v
+++ b/Ensf_dans.v
@@ -50,7 +50,7 @@ Require Import Ensf_types.
 Inductive dans : Elt -> Ensf -> Prop :=
   | dans_add1 : forall (x : Elt) (e : Ensf), dans x (add x e)
   | dans_add2 : forall (x y : Elt) (e : Ensf), dans x e -> dans x (add y e).
-Hint Resolve dans_add1 dans_add2: v62.
+Hint Resolve dans_add1 dans_add2.
  
 (*  Quelques resultats concernant l'appartenance...  *)
  
@@ -61,7 +61,7 @@ simple inversion H.
 left.
 injection H1.
 intros.
-apply trans_equal with x0; [ auto with v62 | assumption ].
+apply trans_equal with x0; [ auto | assumption ].
 
 intro.
 right.
@@ -76,29 +76,29 @@ Lemma dans_add_contr :
  forall (x y : Elt) (e : Ensf), y <> x -> ~ dans x e -> ~ dans x (add y e).
 intros; red in |- *; intro.
 absurd (y = x \/ dans x e).
-2: apply dans_add; auto with v62.
+2: apply dans_add; auto.
 red in |- *.
 intro.
-elim H2; auto with v62.
+elim H2; auto.
 Qed.
  
 Lemma empty_empty : forall E : Elt, ~ dans E empty.
 unfold not in |- *; intros E H.
 simple inversion H; [ discriminate H1 | discriminate H2 ].
 Qed.
-Hint Resolve empty_empty: v62.
+Hint Resolve empty_empty.
  
 Lemma dans_empty_imp_P : forall (x : Elt) (P : Prop), dans x empty -> P.
 intros.
 elimtype False.
-cut (~ dans x empty); auto with v62.
+cut (~ dans x empty); auto.
 Qed.
  
 Lemma singl2 : forall x : Elt, dans x (singleton x).
 unfold singleton in |- *.
-auto with v62.
+auto.
 Qed.
-Hint Resolve singl2: v62.
+Hint Resolve singl2.
 
 Unset Structural Injection.
 
@@ -112,4 +112,4 @@ injection H2; intros.
 apply dans_empty_imp_P with x0.
 rewrite <- H0; assumption.
 Qed.
-Hint Resolve singl2_inv: v62.
+Hint Resolve singl2_inv.

--- a/Ensf_disj.v
+++ b/Ensf_disj.v
@@ -67,30 +67,30 @@ Lemma dans_map_injg :
  forall (e : Ensf) (x : Elt), dans x (map injgauche e) -> dans (first x) e.
 intros.
 cut (exists y : Elt, dans y e /\ x = injgauche y).
-2: apply dans_map; auto with v62.
+2: apply dans_map; auto.
 intro Ht; elim Ht; clear Ht.
 intros y Ht; elim Ht; clear Ht.
 intros.  
 unfold injgauche in H1.
-replace (first x) with y; auto with v62.
+replace (first x) with y; auto.
 symmetry  in |- *.
-replace y with (first (couple y zero)); auto with v62.
-apply (f_equal (A:=Elt) (B:=Elt)); auto with v62.
+replace y with (first (couple y zero)); auto.
+apply (f_equal (A:=Elt) (B:=Elt)); auto.
 Qed.
 
 Lemma dans_map_injd :
  forall (e : Ensf) (x : Elt), dans x (map injdroite e) -> dans (first x) e.
 intros.
 cut (exists y : Elt, dans y e /\ x = injdroite y).
-2: apply dans_map; auto with v62.
+2: apply dans_map; auto.
 intro Ht; elim Ht; clear Ht.
 intros y Ht; elim Ht; clear Ht.
 intros.  
 unfold injdroite in H1.
-replace (first x) with y; auto with v62.
+replace (first x) with y; auto.
 symmetry  in |- *.
-replace y with (first (couple y un)); auto with v62.
-apply (f_equal (A:=Elt) (B:=Elt)); auto with v62.
+replace y with (first (couple y un)); auto.
+apply (f_equal (A:=Elt) (B:=Elt)); auto.
 Qed.
 
 Lemma absurd_injg_injd :
@@ -98,14 +98,14 @@ Lemma absurd_injg_injd :
  dans x (map injgauche e) -> ~ dans x (map injdroite f).
 intros.
 cut (exists y : Elt, dans y e /\ x = injgauche y).
-2: apply dans_map; auto with v62.
+2: apply dans_map; auto.
 intro Ht; elim Ht; clear Ht.
 intros y Ht; elim Ht; clear Ht.
 intros.  
 red in |- *.
 intro.
 cut (exists y' : Elt, dans y' f /\ x = injdroite y' :>Elt).
-2: apply dans_map; auto with v62.
+2: apply dans_map; auto.
 intro Ht; elim Ht; clear Ht.
 intros y' Ht; elim Ht; clear Ht.
 intros.  
@@ -116,11 +116,11 @@ discriminate.
 
 unfold injdroite in H4.
 unfold injgauche in H1.
-replace zero with (second (couple y zero)); auto with v62.
-replace un with (second (couple y' un)); auto with v62.
+replace zero with (second (couple y zero)); auto.
+replace un with (second (couple y' un)); auto.
 rewrite <- H4.
 rewrite <- H1.
-auto with v62.
+auto.
 Qed.
 
 (*									*)
@@ -137,12 +137,12 @@ Lemma union_disj1 :
 unfold union_disj in |- *.
 intros.
 cut (dans x (map injgauche a) \/ dans x (map injdroite b)).
-2: auto with v62.
+2: auto.
 intro H0; elim H0; clear H0.
 intro; left.
-apply dans_map; auto with v62.
+apply dans_map; auto.
 intro; right.
-apply dans_map; auto with v62.
+apply dans_map; auto.
 Qed.
 
 Lemma union_disj_d :
@@ -152,7 +152,7 @@ intros.
 unfold union_disj in |- *.
 apply union_d.
 apply dans_map_inv.
-auto with v62.
+auto.
 Qed.
 
 Lemma union_disj_g :
@@ -162,7 +162,7 @@ intros.
 unfold union_disj in |- *.
 apply union_g.
 apply dans_map_inv.
-auto with v62.
+auto.
 Qed.
 
 Lemma inclus_union_disj :
@@ -171,32 +171,32 @@ Lemma inclus_union_disj :
 unfold inclus in |- *.
 intros.
 unfold union_disj in H1.
-cut (dans x (map injgauche a) \/ dans x (map injdroite b)); auto with v62.
+cut (dans x (map injgauche a) \/ dans x (map injdroite b)); auto.
 intro Ht; elim Ht; clear Ht.
 
 intro.
 cut (exists y : Elt, dans y a /\ x = injgauche y).
-2: apply dans_map; auto with v62.
+2: apply dans_map; auto.
 intro Ht; elim Ht; clear Ht.
 intros y Ht; elim Ht; clear Ht; intros H3 H4.
-cut (dans y c); auto with v62.
+cut (dans y c); auto.
 intro.
 unfold union_disj in |- *.
 apply union_g.
 rewrite H4.
-apply dans_map_inv; auto with v62.
+apply dans_map_inv; auto.
 
 intro.
 cut (exists y : Elt, dans y b /\ x = injdroite y :>Elt).
-2: apply dans_map; auto with v62.
+2: apply dans_map; auto.
 intro Ht; elim Ht; clear Ht.
 intros y Ht; elim Ht; clear Ht; intros H3 H4.
-cut (dans y d); auto with v62.
+cut (dans y d); auto.
 intro.
 unfold union_disj in |- *.
 apply union_d.
 rewrite H4.
-apply dans_map_inv; auto with v62.
+apply dans_map_inv; auto.
 Qed.
 
 (* 									*)
@@ -212,4 +212,4 @@ rewrite X.
 rewrite Y.
 apply refl_equal.
 Qed.
-Hint Resolve pair_equal: v62.
+Hint Resolve pair_equal.

--- a/Ensf_inclus.v
+++ b/Ensf_inclus.v
@@ -57,22 +57,22 @@ Require Import Ensf_produit.
 
 Definition inclus (A B : Ensf) : Prop := forall x : Elt, dans x A -> dans x B.
 
-Hint Unfold inclus: v62.
+Hint Unfold inclus.
 
 Lemma empty_inclus : forall x : Ensf, inclus empty x.
 unfold inclus in |- *; intros.
-absurd (dans x0 empty); auto with v62.
+absurd (dans x0 empty); auto.
 Qed.
-Hint Resolve empty_inclus: v62.
+Hint Resolve empty_inclus.
 
 Lemma refl_inclus : forall x : Ensf, inclus x x.
-auto with v62.
+auto.
 Qed.
-Hint Resolve refl_inclus: v62.
+Hint Resolve refl_inclus.
 
 Lemma inclus_trans :
  forall a b c : Ensf, inclus a b -> inclus b c -> inclus a c.
-auto with v62.
+auto.
 Qed.
 
 Lemma cart_inclus :
@@ -83,36 +83,36 @@ intros.
 cut
  (exists x1 : Elt,
     (exists x2 : Elt, dans x1 a /\ dans x2 c /\ x = couple x1 x2)).
-2: apply coupl3; auto with v62.
+2: apply coupl3; auto.
 intro H2; elim H2; clear H2.
 intros x1 H2; elim H2; clear H2.
 intros x2 H2; elim H2; clear H2.
 intros H2 H3; elim H3; clear H3.
 intros H3 H4.
 rewrite H4.
-auto with v62.
+auto.
 Qed.
-Hint Resolve cart_inclus: v62.
+Hint Resolve cart_inclus.
 
 Lemma inclus_add :
  forall (a b : Ensf) (y : Elt), inclus a b -> inclus a (add y b).
-auto with v62.
+auto.
 Qed.
-Hint Resolve inclus_add: v62.
+Hint Resolve inclus_add.
 
 Lemma singl_inclus_add :
  forall (e : Elt) (a : Ensf), inclus (singleton e) (add e a).
 unfold inclus in |- *.
 intros e a x H.
-cut (x = e); auto with v62.
+cut (x = e); auto.
 intro H0.
-rewrite H0; auto with v62.
+rewrite H0; auto.
 Qed.
-Hint Resolve singl_inclus_add: v62.
+Hint Resolve singl_inclus_add.
 
 Lemma inclus_singl :
  forall (e : Elt) (a : Ensf), inclus (singleton e) a -> dans e a.
-auto with v62.
+auto.
 Qed.
 
 
@@ -121,41 +121,41 @@ Lemma add_inclus :
 unfold inclus in |- *.
 intros.
 cut (x = x0 \/ dans x0 a).
-2: apply dans_add; auto with v62.
+2: apply dans_add; auto.
 intro H2; elim H2; clear H2.
-intro H2; rewrite <- H2; auto with v62.
-auto with v62.
+intro H2; rewrite <- H2; auto.
+auto.
 Qed.
-Hint Resolve add_inclus: v62.
+Hint Resolve add_inclus.
 
 Lemma dans_trans :
  forall (x : Elt) (a b : Ensf), dans x a -> inclus a b -> dans x b.
-auto with v62.
+auto.
 Qed.
 
 Lemma union_inclus :
  forall a b c : Ensf, inclus a c -> inclus b c -> inclus (union a b) c.
 unfold inclus in |- *.
 intros.
-cut (dans x a \/ dans x b); auto with v62.
-intro H2; elim H2; auto with v62.
+cut (dans x a \/ dans x b); auto.
+intro H2; elim H2; auto.
 Qed.
-Hint Resolve union_inclus: v62.
+Hint Resolve union_inclus.
 
 Lemma inclus_g : forall a b : Ensf, inclus a (union a b).
-auto with v62.
+auto.
 Qed.
 
 Lemma inclus_d : forall a b : Ensf, inclus b (union a b).
-auto with v62.
+auto.
 Qed.
 
 Lemma inclus_g2 : forall A B C : Ensf, inclus A B -> inclus A (union B C).
-auto with v62.
+auto.
 Qed.
-Hint Resolve inclus_g2: v62.
+Hint Resolve inclus_g2.
 
 Lemma inclus_d2 : forall A B C : Ensf, inclus A C -> inclus A (union B C).
-auto with v62.
+auto.
 Qed.
-Hint Resolve inclus_d2: v62.
+Hint Resolve inclus_d2.

--- a/Ensf_inter.v
+++ b/Ensf_inter.v
@@ -65,12 +65,12 @@ elim H0; clear H0.
 intros H0 H1; elim H1; clear H1; intros H1 H2.
 elim H; clear H.
 intros H3 H4; elim H4; clear H4; intros H4 H5.
-split; auto with v62.
+split; auto.
 split.
 apply empty_inclus.
 intros.
-cut (dans x b \/ dans x c); auto with v62.
-intro H7; elim H7; auto with v62.
+cut (dans x b \/ dans x c); auto.
+intro H7; elim H7; auto.
 Qed.
 
 Lemma inter_union :
@@ -82,11 +82,11 @@ elim H0; clear H0.
 intros H0 H1; elim H1; clear H1; intros H1 H2.
 elim H; clear H.
 intros H3 H4; elim H4; clear H4; intros H4 H5.
-split; auto with v62.
-split; auto with v62.
+split; auto.
+split; auto.
 intros.
-cut (dans x A \/ dans x B); auto with v62.
-intro H7; elim H7; auto with v62.
+cut (dans x A \/ dans x B); auto.
+intro H7; elim H7; auto.
 Qed.
 
 Lemma inter_dans :
@@ -95,14 +95,14 @@ unfold inter in |- *.
 intros.
 elim H; clear H; intros H Ht; elim Ht; clear Ht; intros H1 H2.
 red in |- *; intro.
-cut (dans x empty); auto with v62.
+cut (dans x empty); auto.
 intro.
-apply dans_empty_imp_P with x; auto with v62.
+apply dans_empty_imp_P with x; auto.
 Qed.
 
 Lemma sym_inter : forall A B C : Ensf, inter A B C -> inter B A C.
 unfold inter in |- *.
 intros.
 elim H; clear H; intros H Ht; elim Ht; clear Ht; intros H0 H1.
-auto with v62.
+auto.
 Qed.

--- a/Ensf_map.v
+++ b/Ensf_map.v
@@ -69,25 +69,25 @@ intros f.
 simple induction a.
 simpl in |- *.
 intros x H.
-absurd (dans x empty); auto with v62.
+absurd (dans x empty); auto.
 
 intros a0 b H x.
 simpl in |- *.
 intro.
 cut (f a0 = x :>Elt \/ dans x (map f b)).
-2: apply dans_add; auto with v62.
+2: apply dans_add; auto.
 intro H1; elim H1; clear H1.
-intro; exists a0; auto with v62.
+intro; exists a0; auto.
 intro.
 cut (exists y : Elt, dans y b /\ x = f y).
 intro H2; elim H2; clear H2.
-2: auto with v62.
+2: auto.
 intros x0 H2; elim H2; clear H2.
 intros.
 exists x0.
-split; auto with v62.
+split; auto.
 Qed.
-Hint Resolve dans_map: v62.
+Hint Resolve dans_map.
 
 Lemma dans_map_inv :
  forall (f : Elt -> Elt) (x : Elt) (a : Ensf),
@@ -95,49 +95,49 @@ Lemma dans_map_inv :
 intros f x.
 simple induction a.
 intro.
-apply (dans_empty_imp_P x); auto with v62.
+apply (dans_empty_imp_P x); auto.
 
 intros a0 b H.
 simpl in |- *.
 intro H1.
 cut (a0 = x :>Elt \/ dans x b).
-2: apply dans_add; auto with v62.
+2: apply dans_add; auto.
 intro H2; elim H2; clear H2.
 intro.
-rewrite H0; auto with v62.
-auto with v62.
+rewrite H0; auto.
+auto.
 Qed.
-Hint Resolve dans_map_inv: v62.
+Hint Resolve dans_map_inv.
 
 Lemma map_union :
  forall (f : Elt -> Elt) (a b : Ensf),
  union (map f a) (map f b) = map f (union a b) :>Ensf.
 intro f.
-simple induction a; simpl in |- *; auto with v62.
+simple induction a; simpl in |- *; auto.
 Qed.
-Hint Resolve map_union: v62.
+Hint Resolve map_union.
 
 Lemma dans_map_trans :
  forall (x : Elt) (f : Elt -> Elt) (a b : Ensf),
  dans x (map f a) -> inclus a b -> dans x (map f b).
 intros.
 cut (exists y : Elt, dans y a /\ x = f y :>Elt).
-2: apply dans_map; auto with v62. 
+2: apply dans_map; auto. 
 intro Ht; elim Ht; clear Ht.
 intros y Ht; elim Ht; clear Ht.
 intros.
 cut (dans y b).
-2: apply dans_trans with a; auto with v62.
+2: apply dans_trans with a; auto.
 intro.
 rewrite H2.
-apply dans_map_inv; auto with v62.
+apply dans_map_inv; auto.
 Qed.
 
 Lemma map_egal :
  forall (f g : Elt -> Elt) (E : Ensf),
  (forall x : Elt, dans x E -> f x = g x :>Elt) -> map f E = map g E :>Ensf.
 intros f g.
-simple induction E; simpl in |- *; auto with v62.
+simple induction E; simpl in |- *; auto.
 Qed.
 
 Lemma map_inclus :
@@ -146,9 +146,9 @@ Lemma map_inclus :
 unfold inclus in |- *.
 intros.
 cut (exists y : Elt, dans y a /\ x = f y :>Elt).
-2: apply dans_map; auto with v62.
+2: apply dans_map; auto.
 intro Ht; elim Ht; clear Ht; intros y Ht; elim Ht; clear Ht; intros.
-cut (dans y b); auto with v62.
+cut (dans y b); auto.
 intro.
-replace x with (f y); auto with v62.
+replace x with (f y); auto.
 Qed.

--- a/Ensf_produit.v
+++ b/Ensf_produit.v
@@ -90,24 +90,24 @@ intros x y x0.
 simple induction b.
 simpl in |- *.
 intro.
-apply (dans_empty_imp_P (couple x y)); auto with v62.
+apply (dans_empty_imp_P (couple x y)); auto.
 
 intros a b0 H.
 simpl in |- *.
 intro.
 cut (couple x0 a = couple x y :>Elt \/ dans (couple x y) (singleprod x0 b0)).
-2: apply dans_add; auto with v62.
+2: apply dans_add; auto.
 intro H1; elim H1; clear H1.
 intro H1.
 injection H1; intros.
-split; auto with v62.
-rewrite H2; auto with v62.
+split; auto.
+rewrite H2; auto.
 
 intro.
-cut (x = x0 :>Elt /\ dans y b0); auto with v62.
+cut (x = x0 :>Elt /\ dans y b0); auto.
 intro H2; elim H2; clear H2.
 intros.
-split; auto with v62.
+split; auto.
 Qed.
 
 (*  On peut ensuite en deduire que si (x,y) est dans AxB alors 		*)
@@ -121,27 +121,27 @@ simple induction a.
 intro b.
 simpl in |- *.
 intro.
-apply (dans_empty_imp_P (couple x y)); auto with v62.
+apply (dans_empty_imp_P (couple x y)); auto.
 
 intros a0 b H b0.
 simpl in |- *.
 intro.
 cut
  (dans (couple x y) (singleprod a0 b0) \/ dans (couple x y) (prodcart b b0)).
-2: apply dans_union; auto with v62.
+2: apply dans_union; auto.
 intro H1; elim H1; clear H1.
 intro H1.
 cut (x = a0 :>Elt /\ dans y b0).
-2: apply dans_singleprod; auto with v62.
+2: apply dans_singleprod; auto.
 intro H2; elim H2; clear H2.
 intros.
 rewrite H2.
-split; auto with v62.
+split; auto.
 intro.
-cut (dans x b /\ dans y b0); auto with v62.
+cut (dans x b /\ dans y b0); auto.
 intro H2; elim H2; clear H2.
 intros.
-split; auto with v62.
+split; auto.
 Qed.
 
 (*  Plus facile : l'inverse...						*)
@@ -152,15 +152,15 @@ Lemma dans_single :
 intros x y.
 simple induction a.
 intro.
-apply (dans_empty_imp_P y); auto with v62.
+apply (dans_empty_imp_P y); auto.
 intros a0 b H H1.
 cut (a0 = y :>Elt \/ dans y b).
-2: apply dans_add; auto with v62.
+2: apply dans_add; auto.
 intro H2; elim H2; clear H2.
 intro.
 simpl in |- *.
-rewrite H0; auto with v62.
-simpl in |- *; auto with v62.
+rewrite H0; auto.
+simpl in |- *; auto.
 Qed.
 
 Lemma coupl2_inv :
@@ -169,24 +169,24 @@ Lemma coupl2_inv :
 intros x y.
 simple induction a.
 intros b H.
-apply (dans_empty_imp_P x); auto with v62.
+apply (dans_empty_imp_P x); auto.
 
 intros a0 b H b0 H0.
 cut (a0 = x :>Elt \/ dans x b).
-2: apply dans_add; auto with v62.
+2: apply dans_add; auto.
 simpl in |- *.
 intro H1; elim H1; clear H1.
 intros H1 H2.
 apply dans_union_inv.
 left.
 rewrite H1.
-apply dans_single; auto with v62.
+apply dans_single; auto.
 intros H1 H2.
 apply dans_union_inv.
 right.
-auto with v62.
+auto.
 Qed.
-Hint Resolve coupl2_inv: v62.
+Hint Resolve coupl2_inv.
 
 (*  De meme on commence ici par monter que si x est dans		*)
 (*  (singleprod x0 b) alors x est de la forme (x0,y) avec y dans b	*)
@@ -197,23 +197,23 @@ Lemma dans_singleprod2 :
 intros x x0.
 simple induction b.
 intro.
-apply (dans_empty_imp_P x); auto with v62.
+apply (dans_empty_imp_P x); auto.
 intros a b0 H.
 simpl in |- *.
 intro.
 cut (couple x0 a = x :>Elt \/ dans x (singleprod x0 b0)).
-2: apply dans_add; auto with v62.
+2: apply dans_add; auto.
 intro H1; elim H1; clear H1.
 intro.
-exists a; auto with v62.
+exists a; auto.
 intro.
-cut (exists y : Elt, x = couple x0 y /\ dans y b0); auto with v62.
+cut (exists y : Elt, x = couple x0 y /\ dans y b0); auto.
 intro H2; elim H2; clear H2.
 intros.
 exists x1.
 elim H2; clear H2.
 intros.
-split; auto with v62.
+split; auto.
 Qed.
 
 (*  On peut ensuite en deduire que si x est dans AxB alors x est de la	*)
@@ -228,28 +228,28 @@ simple induction a.
 intro b.
 simpl in |- *.
 intros x H.
-apply (dans_empty_imp_P x); auto with v62.
+apply (dans_empty_imp_P x); auto.
 
 intros a0 b H b0 x.
 simpl in |- *.
 intro.
-cut (dans x (singleprod a0 b0) \/ dans x (prodcart b b0)); auto with v62.
+cut (dans x (singleprod a0 b0) \/ dans x (prodcart b b0)); auto.
 intro H1; elim H1; clear H1.
 intro.
 cut (exists y : Elt, x = couple a0 y /\ dans y b0).
-2: apply dans_singleprod2; auto with v62.
+2: apply dans_singleprod2; auto.
 intro H2; elim H2; clear H2.
 intros x0 H2.
 exists a0.
 exists x0.
 elim H2; clear H2.
 intros.
-split; auto with v62.
+split; auto.
 intro.
 cut
  (exists x1 : Elt,
     (exists x2 : Elt, dans x1 b /\ dans x2 b0 /\ x = couple x1 x2));
- auto with v62.
+ auto.
 intro H2; elim H2; clear H2.
 intros x0 H2; elim H2; clear H2.
 intros x1 H2; elim H2; clear H2.
@@ -257,5 +257,5 @@ intros H2 H3; elim H3; clear H3.
 intros H4 H5.
 exists x0.
 exists x1.
-split; auto with v62.
+split; auto.
 Qed.

--- a/Ensf_types.v
+++ b/Ensf_types.v
@@ -76,7 +76,7 @@ Definition natural_inv (e : Elt) : nat :=
   end.
 
 Lemma nat_invol : forall n : nat, natural_inv (natural n) = n.
-auto with v62.
+auto.
 Qed.
 (*
 Definition word_inv : Elt -> Word :=
@@ -102,9 +102,9 @@ Lemma add_add :
 intros.
 rewrite H.
 rewrite H0.
-trivial with v62.
+trivial.
 Qed.
-Hint Resolve add_add: v62.
+Hint Resolve add_add.
 
 
 Lemma couple_couple :
@@ -112,19 +112,19 @@ Lemma couple_couple :
 intros.
 rewrite H.
 rewrite H0.
-trivial with v62.
+trivial.
 Qed.
 
 Lemma word_word : forall a b : Word, a = b -> word a = word b.
 intros.
-apply (f_equal (A:=Word) (B:=Elt)); auto with v62.
+apply (f_equal (A:=Word) (B:=Elt)); auto.
 Qed.
-Hint Resolve word_word: v62.
+Hint Resolve word_word.
  
 Lemma word_word_inv : forall a b : Word, word a = word b -> a = b.
 intros a b H.
 injection H.
-trivial with v62.
+trivial.
 Qed.
 
 (*  Quelques simplifications  *)
@@ -143,5 +143,5 @@ Qed.
 
 Lemma equal_add : forall (a b : Ensf) (e : Elt), a = b -> add e a = add e b.
 intros.
-apply (f_equal (A:=Ensf) (B:=Ensf)); auto with v62.
+apply (f_equal (A:=Ensf) (B:=Ensf)); auto.
 Qed.

--- a/Ensf_union.v
+++ b/Ensf_union.v
@@ -64,57 +64,57 @@ Lemma union_a_empty : forall a : Ensf, a = union a empty :>Ensf.
 simple induction a.
 apply refl_equal.
 intros a0 b H.
-simpl in |- *; auto with v62.
+simpl in |- *; auto.
 Qed.
-Hint Resolve union_a_empty: v62.
+Hint Resolve union_a_empty.
 
 
 Lemma dans_union :
  forall (x : Elt) (a b : Ensf), dans x (union a b) -> dans x a \/ dans x b.
 intros x.
 simple induction a.
-auto with v62.
+auto.
 
 intros a0 b H b0.
 simpl in |- *.
 intro H0.
 cut (a0 = x :>Elt \/ dans x (union b b0)).
-2: apply dans_add; auto with v62.
+2: apply dans_add; auto.
 intro H1; elim H1.
 intro; left.
-rewrite H2; auto with v62.
+rewrite H2; auto.
 intro.
-cut (dans x b \/ dans x b0); auto with v62.
-intro H3; elim H3; auto with v62.
+cut (dans x b \/ dans x b0); auto.
+intro H3; elim H3; auto.
 Qed.
-Hint Resolve dans_union: v62.
+Hint Resolve dans_union.
 
 
 Lemma union_g : forall (x : Elt) (a b : Ensf), dans x a -> dans x (union a b).
 intro x.
 simple induction a.
 intros.
-apply (dans_empty_imp_P x); auto with v62.
+apply (dans_empty_imp_P x); auto.
 intros a0 b H b0.
 simpl in |- *.
 intro.
 cut (a0 = x :>Elt \/ dans x b).
-2: apply dans_add; auto with v62.
+2: apply dans_add; auto.
 intro H1; elim H1; clear H1.
 intro H1.
-rewrite H1; auto with v62.
-auto with v62.
+rewrite H1; auto.
+auto.
 Qed.
-Hint Resolve union_g: v62.
+Hint Resolve union_g.
 
 Lemma union_d : forall (x : Elt) (a b : Ensf), dans x b -> dans x (union a b).
 intro x.
-simple induction a; simpl in |- *; auto with v62.
+simple induction a; simpl in |- *; auto.
 Qed.
-Hint Resolve union_d: v62.
+Hint Resolve union_d.
 
 
 Lemma dans_union_inv :
  forall (x : Elt) (a b : Ensf), dans x a \/ dans x b -> dans x (union a b).
-intros x a b H; elim H; auto with v62.
+intros x a b H; elim H; auto.
 Qed.

--- a/Max.v
+++ b/Max.v
@@ -84,9 +84,9 @@ Fixpoint sup (e : Ensf) : nat :=
 Lemma sup_add :
  forall (x : Elt) (e : Ensf), sup (add x e) = max (Z x) (sup e) :>nat.
 intros x.
-simple induction e; auto with v62.
+simple induction e; auto.
 Qed.
-Hint Resolve sup_add: v62.
+Hint Resolve sup_add.
 
 (*  Finalement inutile :  *)
 (*
@@ -95,11 +95,11 @@ Intros; Red; Intro.
 Absurd (<nat>n=m).
 Assumption.
 Replace n with (natural_inv (natural n)).
-2:Auto with v62.
+2:Auto.
 Replace m with (natural_inv (natural m)).
-2:Auto with v62.
+2:Auto.
 Elim H0.
-Auto with v62.
+Auto.
 Save.
 *)
 
@@ -109,22 +109,22 @@ Lemma lt_diff : (n,m:nat)(lt m n)->~(<nat>n=m).
 Intros.
 Red.
 Intro.
-Cut (lt m n); Auto with v62.
+Cut (lt m n); Auto.
 Elim H0.
 Change ~(lt n n).
-Auto with v62.
+Auto.
 Save.
 *)
 
 Lemma elt_not_sym : forall a b : Elt, a <> b :>Elt -> b <> a :>Elt.
-auto with v62.
+auto.
 Qed.
 
 (*  (Z (natural n)) vaut (S n), donc est plus grand que n		*)
 
 Lemma lt_n_Z : forall n : nat, n < Z (natural n).
 intro.
-replace (Z (natural n)) with (S n); auto with v62.
+replace (Z (natural n)) with (S n); auto.
 Qed.
 
 (*									*)
@@ -135,17 +135,17 @@ Qed.
 Lemma lt_n_sup : forall (x : Ensf) (n : nat), dans (natural n) x -> n < sup x.
 simple induction x.
 intros.
-absurd (dans (natural n) empty); auto with v62.
+absurd (dans (natural n) empty); auto.
 intros a b H n H0.
 replace (sup (add a b)) with (max (Z a) (sup b)).
-2: auto with v62.
+2: auto.
 cut (n < Z a \/ n < sup b).
 intro.
-elim H1; auto with v62.
-intros; apply lt_le_trans with (Z a); auto with v62.
-intros; apply lt_le_trans with (sup b); auto with v62.
+elim H1; auto.
+intros; apply lt_le_trans with (Z a); auto with arith.
+intros; apply lt_le_trans with (sup b); auto with arith.
 cut (a = natural n :>Elt \/ dans (natural n) b).
-2: apply dans_add; auto with v62.
+2: apply dans_add; auto.
 intro.
 elim H1.
 intro; left.

--- a/PushdownAutomata.v
+++ b/PushdownAutomata.v
@@ -79,14 +79,14 @@ Definition P_automata := inmonoid P wd /\ inmonoid P wa /\ Transition.
 Lemma P_automata_1 : P_automata -> inmonoid P wd.
 unfold P_automata in |- *.
 intro temp; elim temp.
-auto with v62.
+auto.
 Qed.
 
 Lemma P_automata_2 : P_automata -> Transition.
 unfold P_automata in |- *.
 intro temp; elim temp; clear temp.
 intros H temp; elim temp; clear temp.
-auto with v62.
+auto.
 Qed.
 
 
@@ -114,7 +114,7 @@ Definition LA (u : Word) :=
 
 Lemma LA_langage : islanguage X LA.
 unfold LA, islanguage in |- *.
-intros w temp; elim temp; clear temp; auto with v62.
+intros w temp; elim temp; clear temp; auto.
 Qed.
 
 

--- a/Rat.v
+++ b/Rat.v
@@ -78,7 +78,7 @@ unfold lstar in |- *.
 intros.
 elim H0; clear H0.
 intros x H0.
-apply (H x w); auto with v62.
+apply (H x w); auto.
 Qed.
 
 (*									*)
@@ -95,7 +95,7 @@ exists w.
 exists nil.
 split; [ assumption | split ]. 
 unfold lpuiss in |- *.
-unfold lword in |- *; auto with v62.
+unfold lword in |- *; auto.
 symmetry  in |- *.
 apply Append_w_nil.
 Qed.

--- a/RatReg.v
+++ b/RatReg.v
@@ -62,7 +62,7 @@ unfold reconnait at 1 in |- *.
 split.
 apply inmonoid_nil.
 exists zero; exists zero.
-auto with v62.
+auto.
 Qed.
 
 
@@ -75,7 +75,7 @@ Lemma lwordnil_is_reg2 :
 unfold reconnait at 1 in |- *.
 simple induction w.
 
-auto with v62.
+auto.
 
 intros x w0 H H0.
 clear H.
@@ -87,11 +87,11 @@ elim H2; intros; clear H2.
 cut
  (Chemin x0 x1 (singleton zero) (prodcart empty (prodcart alph empty))
     (cons x w0)).
-2: auto with v62.
+2: auto.
 unfold Chemin in |- *; simpl in |- *.
 intro H2.
 absurd (dans x0 empty).
-auto with v62.
+auto.
 
 elim H2; intros; clear H2.
 elim H4; intros; clear H4.
@@ -123,7 +123,7 @@ exists (singleton zero).
 exists (prodcart empty (prodcart alph empty)).
 
 split.
-red in |- *; auto with v62.
+red in |- *; auto.
 
 red in |- *; split.
 red in |- *.
@@ -147,7 +147,7 @@ cut
           (exists d : Ensf,
              automate q (singleton e) qa d /\
              eqwordset (reconnait q (singleton e) qa d) (lword nil))))). 
-2: apply lwordnil_is_regS; auto with v62.
+2: apply lwordnil_is_regS; auto.
 intro H; elim H; clear H.
 intros q H; elim H; clear H.
 intros e H; elim H; clear H.
@@ -159,7 +159,7 @@ exists q.
 exists (singleton e).
 exists qa.
 exists d.
-auto with v62.
+auto.
 Qed.
 
 (*  Le gros morceau...							*)
@@ -173,26 +173,26 @@ Lemma extension_qd :
  chemin e1 e2 (add e0 q) (add (couple e0 (couple a e3)) d) w.
 simple induction w.
 intros.
-cut (Chemin e1 e2 q d nil); auto with v62.
+cut (Chemin e1 e2 q d nil); auto.
 intro.
-cut (dans e1 q /\ e1 = e2 :>Elt); auto with v62.
-intro H1; elim H1; auto with v62.
+cut (dans e1 q /\ e1 = e2 :>Elt); auto.
+intro H1; elim H1; auto.
 
 intros x w0 H e0 e1 e2 e3 a q d H0.
-cut (Chemin e1 e2 q d (cons x w0)); auto with v62.
+cut (Chemin e1 e2 q d (cons x w0)); auto.
 intro.
 cut
  (exists e : Elt,
     chemin e e2 q d w0 /\
     dans e1 q /\ dans x alph /\ dans (couple e1 (couple x e)) d);
- auto with v62.
+ auto.
 intro H2; elim H2; clear H2.
 intros e H2; elim H2; clear H2.
 intros H2 H3; elim H3; clear H3.
 intros H3 H4; elim H4; clear H4.
 intros H4 H5.
 apply (chemin_cons e e2 (add e0 q) (add (couple e0 (couple a e3)) d) w0 e1 x);
- auto with v62.
+ auto.
 Qed.
 
 (*  Si un automate reconnait un mot w sans utiliser l'etat e0 alors	*)
@@ -209,14 +209,14 @@ Lemma restriction_aut :
 simple induction w.
 intros.
 cut (Chemin e e2 (add e0 q) (add (couple e0 (couple a e3)) d) nil);
- auto with v62.
+ auto.
 intro.
-cut (dans e (add e0 q) /\ e = e2 :>Elt); auto with v62.
-intro H4; elim H4; auto with v62.
+cut (dans e (add e0 q) /\ e = e2 :>Elt); auto.
+intro H4; elim H4; auto.
 
 intros x w0 H e0 e e2 e3 a q d H0 H1 H2 H3.
 cut (Chemin e e2 (add e0 q) (add (couple e0 (couple a e3)) d) (cons x w0));
- auto with v62.
+ auto.
 intro.
 cut
  (exists e12 : Elt,
@@ -224,48 +224,48 @@ cut
     dans e (add e0 q) /\
     dans x alph /\
     dans (couple e (couple x e12)) (add (couple e0 (couple a e3)) d));
- auto with v62.
+ auto.
 intro H5; elim H5; clear H5.
 intros e12 H5; elim H5; clear H5.
 intros H5 H6; elim H6; clear H6.
 intros H6 H7; elim H7; clear H7.
 intros H7 H8.
-apply (chemin_cons e12 e2 q d w0 e x); auto with v62.
-apply (H e0 e12 e2 e3 a q d); auto with v62.
+apply (chemin_cons e12 e2 q d w0 e x); auto.
+apply (H e0 e12 e2 e3 a q d); auto.
 
 cut
  (couple e0 (couple a e3) = couple e (couple x e12) :>Elt \/
   dans (couple e (couple x e12)) d).
-2: apply dans_add; auto with v62.
+2: apply dans_add; auto.
 intro H9; elim H9; clear H9.
 intro H9; injection H9 as H12 H11 H10.
-absurd (dans e0 q); auto with v62.
-rewrite H12; auto with v62.
+absurd (dans e0 q); auto.
+rewrite H12; auto.
 
 intro.
 cut (dans (couple e (couple x e12)) (prodcart q (prodcart alph q))).
 2: apply
     (dans_trans (couple e (couple x e12)) d (prodcart q (prodcart alph q)));
-    auto with v62.
+    auto.
 intro.
-cut (dans e q /\ dans (couple x e12) (prodcart alph q)); auto with v62.
-2: apply coupl2; auto with v62.
+cut (dans e q /\ dans (couple x e12) (prodcart alph q)); auto.
+2: apply coupl2; auto.
 intro H11; elim H11; clear H11.
 intros.
 cut (dans x alph /\ dans e12 q).
-2: apply coupl2; auto with v62.
+2: apply coupl2; auto.
 tauto.
 
 cut
  (couple e0 (couple a e3) = couple e (couple x e12) :>Elt \/
   dans (couple e (couple x e12)) d).
-2: apply dans_add; auto with v62.
+2: apply dans_add; auto.
 intro H9; elim H9; clear H9.
 intro H9; injection H9 as H12 H11 H10.
-absurd (dans e0 q); auto with v62.
-rewrite H12; auto with v62.
+absurd (dans e0 q); auto.
+rewrite H12; auto.
 
-auto with v62.
+auto.
 Qed.
 
 (*  Si un automate reconnait w alors en lui rajoutant un etat e0	*)
@@ -285,19 +285,19 @@ intros H H2; elim H2; clear H2.
 intros e12 H2; elim H2; clear H2.
 intros e2 H2; elim H2; clear H2.
 intros H2 H3.
-split; auto with v62.
+split; auto.
 exists e0.
 exists e2.
-split; auto with v62.
+split; auto.
 elim H3; clear H3; intros H3 H4.
-split; auto with v62.
-cut (e12 = e :>Elt); auto with v62.
+split; auto.
+cut (e12 = e :>Elt); auto.
 intro H5; rewrite <- H5.
 
 apply
  (chemin_cons e12 e2 (add e0 q) (add (couple e0 (couple a e12)) d) w e0 a);
- auto with v62.
-apply extension_qd; auto with v62.
+ auto.
+apply extension_qd; auto.
 Qed.
 
 (*									*)
@@ -340,19 +340,19 @@ Intros e1 H3; Elim H3; Clear H3.
 Intros e2 H3; Elim H3; Clear H3.
 Intros H3 H4; Elim H4; Clear H4.
 Intros.
-Cut <Elt>e1=e0; Auto with v62.
+Cut <Elt>e1=e0; Auto.
 Intro.
 Elim H.
 Intros H7 H8.
 Cut <Elt>e1=e2.
-2:Cut (Chemin e1 e2 (add e0 q) (add (couple e0 (couple a e)) d) nil); Auto with v62.
-2:Intro; Cut ( (dans e1 (add e0 q)) /\ (<Elt>e1=e2) ); Auto with v62.
-2:Intro H10; Elim H10; Auto with v62.
+2:Cut (Chemin e1 e2 (add e0 q) (add (couple e0 (couple a e)) d) nil); Auto.
+2:Intro; Cut ( (dans e1 (add e0 q)) /\ (<Elt>e1=e2) ); Auto.
+2:Intro H10; Elim H10; Auto.
 Intro H9.
 Cut (dans e2 q).
-2:Apply (dans_trans e2 qa q); Auto with v62.
+2:Apply (dans_trans e2 qa q); Auto.
 Intro H10.
-Absurd (dans e0 q); Auto with v62.
+Absurd (dans e0 q); Auto.
 Rewrite <- H6.
 Rewrite H9.
 Assumption.
@@ -360,8 +360,8 @@ Assumption.
 Intro.
 Cut False.
 Apply False_imp_P.
-Apply (diff_cons_nil a w0); Auto with v62.
-Apply (diff_cons_nil a w0); Auto with v62.
+Apply (diff_cons_nil a w0); Auto.
+Apply (diff_cons_nil a w0); Auto.
 
 Intros.
 Split.
@@ -373,20 +373,20 @@ Intros H4 H5; Elim H5; Clear H5.
 Intros H5 H6.
 
 
-Cut (Chemin e1 e2 (add e0 q) (add (couple e0 (couple a e)) d) (cons x w1)); Auto with v62.
+Cut (Chemin e1 e2 (add e0 q) (add (couple e0 (couple a e)) d) (cons x w1)); Auto.
 Intro H7; Elim H7; Clear H7.
 Intros e12 H7; Elim H7; Clear H7.
 Intros H7 H8; Elim H8; Clear H8.
 Intros H8 H9; Elim H9; Clear H9.
 Intros H9 H10.
-Cut <Elt>e1=e0; Auto with v62.
+Cut <Elt>e1=e0; Auto.
 Intro H11; Clear H4.
 
 Cut (inclus d (prodcart q (prodcart alph q))).
-2:Apply (automate_def1 q (singleton e) qa d); Auto with v62.
+2:Apply (automate_def1 q (singleton e) qa d); Auto.
 Intro H12.
 Cut (<Elt>(couple e0 (couple a e))=(couple e1 (couple x e12)) \/ (dans (couple e1 (couple x e12)) d)).
-2:Apply dans_add; Auto with v62.
+2:Apply dans_add; Auto.
 Intro H4; Elim H4; Clear H4.
 
 Intro.
@@ -394,66 +394,66 @@ Cut <Elt>a=x.
 Intro.
 2:Cut <Elt>(couple a e)=(couple x e12).
 2:Intro.
-2:Replace a with (first (couple a e)); Auto with v62.
-2:Replace x with (first (couple x e12)); Auto with v62.
-2:Apply (f_equal Elt Elt); Auto with v62.
-2:Replace (couple a e) with (second (couple e0 (couple a e))); Auto with v62.
-2:Replace (couple x e12) with (second (couple e1 (couple x e12))); Auto with v62.
-2:Apply (f_equal Elt Elt); Auto with v62.
+2:Replace a with (first (couple a e)); Auto.
+2:Replace x with (first (couple x e12)); Auto.
+2:Apply (f_equal Elt Elt); Auto.
+2:Replace (couple a e) with (second (couple e0 (couple a e))); Auto.
+2:Replace (couple x e12) with (second (couple e1 (couple x e12))); Auto.
+2:Apply (f_equal Elt Elt); Auto.
 
-Apply cons_cons; Auto with v62.
+Apply cons_cons; Auto.
 
 2:Intro.
-2:Absurd (dans e0 q); Auto with v62.
+2:Absurd (dans e0 q); Auto.
 2:Cut (dans (couple e1 (couple x e12)) (prodcart q (prodcart alph q))).
 2:Intro.
-3:Apply (dans_trans (couple e1 (couple x e12)) d); Auto with v62.
+3:Apply (dans_trans (couple e1 (couple x e12)) d); Auto.
 2:Cut (dans e1 q).
-2:Rewrite H11; Auto with v62.
-2:Cut ( (dans e1 q) /\ (dans (couple x e12) (prodcart alph q))); Auto with v62.
+2:Rewrite H11; Auto.
+2:Cut ( (dans e1 q) /\ (dans (couple x e12) (prodcart alph q))); Auto.
 2:Intro H14; Elim H14; Clear H14.
-2:Auto with v62.
-2:Apply coupl2; Auto with v62.
+2:Auto.
+2:Apply coupl2; Auto.
 
 Cut <Elt>e12=e.
-2:Replace e12 with (second (second (couple e1 (couple x e12)))); Auto with v62.
-2:Replace e with (second (second (couple e0 (couple a e)))); Auto with v62.
+2:Replace e12 with (second (second (couple e1 (couple x e12)))); Auto.
+2:Replace e with (second (second (couple e0 (couple a e)))); Auto.
 2:Apply (f_equal Elt Elt).
-2:Apply (f_equal Elt Elt); Auto with v62.
+2:Apply (f_equal Elt Elt); Auto.
 Intro.
 
 Cut (chemin e e2 (add e0 q) (add (couple e0 (couple a e)) d) w1).
-2:Cut (chemin e12 e2 (add e0 q) (add (couple e0 (couple a e)) d) w1); Auto with v62.
-2:Rewrite H14; Auto with v62.
+2:Cut (chemin e12 e2 (add e0 q) (add (couple e0 (couple a e)) d) w1); Auto.
+2:Rewrite H14; Auto.
 Clear H7; Intro H7.
 
 Cut (reconnait q (singleton e) qa d w1).
 Elim (H0 w1).
-Auto with v62.
+Auto.
 Unfold reconnait.
 Split.
-Apply (inmonoid_cons_inv alph w1 x); Auto with v62.
+Apply (inmonoid_cons_inv alph w1 x); Auto.
 Exists e.
 Exists e2.
-Split; Auto with v62.
-Split; Auto with v62.
+Split; Auto.
+Split; Auto.
 
-Apply (restriction_aut w1 e0 e e2 e a q d ); Auto with v62.
+Apply (restriction_aut w1 e0 e e2 e a q d ); Auto.
 Cut (inclus (singleton e) q).
-Intro; Apply inclus_singl; Auto with v62.
-Apply (automate_def2 q (singleton e) qa d); Auto with v62.
+Intro; Apply inclus_singl; Auto.
+Apply (automate_def2 q (singleton e) qa d); Auto.
 
 Intro H3.
 Cut ((<Elt>a=x)/\(<Word>w0=w1)).
-2:Apply cons_cons_inv; Auto with v62.
+2:Apply cons_cons_inv; Auto.
 Intro H4; Elim H4; Clear H4.
 Intros.
 Rewrite <- H4.
 Rewrite <- H5.
 
-Apply extension_aut; Auto with v62.
+Apply extension_aut; Auto.
 Elim (H0 w0).
-Auto with v62.
+Auto.
 Save.
 ----*)
 
@@ -478,7 +478,7 @@ intro.
 apply lwordnil_is_regS.
 intros a w0 H H4.
 cut (inmonoid alph w0).
-2: apply (inmonoid_cons_inv alph w0 a); auto with v62.
+2: apply (inmonoid_cons_inv alph w0 a); auto.
 intro H5.
 cut
  (exists q : Ensf,
@@ -487,7 +487,7 @@ cut
           (exists d : Ensf,
              automate q (singleton e) qa d /\
              eqwordset (reconnait q (singleton e) qa d) (lword w0)))));
- auto with v62.
+ auto.
 clear H; intro H; elim H; clear H.
 intros q H0; elim H0; clear H0.
 intros e H0; elim H0; clear H0.
@@ -495,7 +495,7 @@ intros qa H0; elim H0; clear H0.
 intros d H0; elim H0; clear H0.
 intros.
 cut (exists e0 : Elt, ~ dans e0 q).
-2: apply exist_other; auto with v62.
+2: apply exist_other; auto.
 intro H2; elim H2; clear H2.
 intros e0 H2.
 exists (add e0 q).
@@ -508,18 +508,18 @@ elim H1; clear H1.
 intros.
 split.
 red in |- *.
-split; auto with v62.
-split; auto with v62.
+split; auto.
+split; auto.
 apply add_inclus.
-apply coupl2_inv; auto with v62.
+apply coupl2_inv; auto.
 apply coupl2_inv.
-apply (inmonoid_cons_inv2 alph a w0); auto with v62.
-cut (dans e q); auto with v62.
-apply (inclus_trans d (prodcart q (prodcart alph q))); auto with v62.
+apply (inmonoid_cons_inv2 alph a w0); auto.
+cut (dans e q); auto.
+apply (inclus_trans d (prodcart q (prodcart alph q))); auto.
 
-apply auto_cons; auto with v62.
-apply (inmonoid_cons_inv2 alph a w0); auto with v62.
-unfold automate in |- *; auto with v62.
+apply auto_cons; auto.
+apply (inmonoid_cons_inv2 alph a w0); auto.
+unfold automate in |- *; auto.
 Qed.
 
 (*									*)
@@ -536,7 +536,7 @@ cut
           (exists d : Ensf,
              automate q (singleton e) qa d /\
              eqwordset (reconnait q (singleton e) qa d) (lword w))))).
-2: apply lword_is_regS; auto with v62.
+2: apply lword_is_regS; auto.
 intro H0; elim H0; clear H0.
 intros q H0; elim H0; clear H0.
 intros e H0; elim H0; clear H0.
@@ -547,7 +547,7 @@ exists q.
 exists (singleton e).
 exists qa.
 exists d.
-auto with v62.
+auto.
 Qed.
 
 (************************************************************************)
@@ -608,7 +608,7 @@ apply
 unfold injg_d1 in |- *.
 apply inclus_tq.
 unfold union_disj in |- *.
-auto with v62.
+auto.
 
 apply
  inclus_trans
@@ -616,7 +616,7 @@ apply
 unfold injd_d2 in |- *.
 apply inclus_tq.
 unfold union_disj in |- *. 
-auto with v62.
+auto.
 Qed.
 
 (* 									*)
@@ -631,7 +631,7 @@ Lemma transition_dans_d1 :
 intros.
 cut
  (dans (couple e1 (couple x e)) (injg_d1 q1 d1) \/
-  dans (couple e1 (couple x e)) (injd_d2 q2 d2)); auto with v62.
+  dans (couple e1 (couple x e)) (injd_d2 q2 d2)); auto.
 intro Ht; elim Ht; clear Ht.
 
 unfold injg_d1 in |- *.
@@ -640,16 +640,16 @@ cut
  (dans (couple e1 (couple x e))
     (prodcart (map injgauche q1) (prodcart alph (map injgauche q1))) /\
   est_dans_d' d1 (couple e1 (couple x e))).
-2: apply dans_tq_imp; auto with v62.
+2: apply dans_tq_imp; auto.
 intro Ht; elim Ht; clear Ht; intros H2 H3.      
 cut
  (dans e1 (map injgauche q1) /\
   dans (couple x e) (prodcart alph (map injgauche q1))).
-2: apply coupl2; auto with v62.
+2: apply coupl2; auto.
 intro Ht; elim Ht; clear Ht; intros H4 H5.
 cut (dans x alph /\ dans e (map injgauche q1)).
-2: apply coupl2; auto with v62.
-intro Ht; elim Ht; clear Ht; auto with v62.
+2: apply coupl2; auto.
+intro Ht; elim Ht; clear Ht; auto.
 
 unfold injd_d2 in |- *.
 intro.
@@ -657,15 +657,15 @@ cut
  (dans (couple e1 (couple x e))
     (prodcart (map injdroite q2) (prodcart alph (map injdroite q2))) /\
   est_dans_d' d2 (couple e1 (couple x e))).
-2: apply dans_tq_imp; auto with v62.
+2: apply dans_tq_imp; auto.
 intro Ht; elim Ht; clear Ht; intros H2 H3.      
 cut
  (dans e1 (map injdroite q2) /\
   dans (couple x e) (prodcart alph (map injdroite q2))).
-2: apply coupl2; auto with v62.
+2: apply coupl2; auto.
 intro Ht; elim Ht; clear Ht; intros H4 H5.
-absurd (dans e1 (map injdroite q2)); auto with v62.
-apply absurd_injg_injd with q1; auto with v62.
+absurd (dans e1 (map injdroite q2)); auto.
+apply absurd_injg_injd with q1; auto.
 Qed.
 
 
@@ -677,7 +677,7 @@ Lemma restriction_transition_d1 :
 intros.
 cut
  (dans (couple e1 (couple x e)) (injg_d1 q1 d1) \/
-  dans (couple e1 (couple x e)) (injd_d2 q2 d2)); auto with v62.
+  dans (couple e1 (couple x e)) (injd_d2 q2 d2)); auto.
 intro Ht; elim Ht; clear Ht.
 
 unfold injg_d1 in |- *.
@@ -686,7 +686,7 @@ cut
  (dans (couple e1 (couple x e))
     (prodcart (map injgauche q1) (prodcart alph (map injgauche q1))) /\
   est_dans_d' d1 (couple e1 (couple x e))).
-2: apply dans_tq_imp; auto with v62.
+2: apply dans_tq_imp; auto.
 intro Ht; elim Ht; clear Ht; intros H2 H3.      
 assumption.
 
@@ -696,15 +696,15 @@ cut
  (dans (couple e1 (couple x e))
     (prodcart (map injdroite q2) (prodcart alph (map injdroite q2))) /\
   est_dans_d' d2 (couple e1 (couple x e))).
-2: apply dans_tq_imp; auto with v62.
+2: apply dans_tq_imp; auto.
 intro Ht; elim Ht; clear Ht; intros H2 H3.      
 cut
  (dans e1 (map injdroite q2) /\
   dans (couple x e) (prodcart alph (map injdroite q2))).
-2: apply coupl2; auto with v62.
+2: apply coupl2; auto.
 intro Ht; elim Ht; clear Ht; intros H4 H5.
-absurd (dans e1 (map injdroite q2)); auto with v62.
-apply absurd_injg_injd with q1; auto with v62.
+absurd (dans e1 (map injdroite q2)); auto.
+apply absurd_injg_injd with q1; auto.
 Qed.
 
 (* 									*)
@@ -725,28 +725,28 @@ simple induction w.
 intros e1 e2 H H0 H1 H2.
 cut
  (Chemin e1 e2 (union_disj q1 q2) (union (injg_d1 q1 d1) (injd_d2 q2 d2)) nil);
- auto with v62.
+ auto.
 intro.
-cut (dans e1 (union_disj q1 q2) /\ e1 = e2 :>Elt); auto with v62.
+cut (dans e1 (union_disj q1 q2) /\ e1 = e2 :>Elt); auto.
 intro Ht; elim Ht; clear Ht; intros H4 H5.
 split.
 apply chemin_nil.
-2: apply (f_equal (A:=Elt) (B:=Elt)); auto with v62.
-apply dans_map_injg; auto with v62.
+2: apply (f_equal (A:=Elt) (B:=Elt)); auto.
+apply dans_map_injg; auto.
 unfold union_disj in H2.
 cut (dans e2 (map injgauche qa1) \/ dans e2 (map injdroite qa2));
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
-auto with v62.
+auto.
 intro.
-absurd (dans e2 (map injdroite qa2)); auto with v62.
+absurd (dans e2 (map injdroite qa2)); auto.
 rewrite <- H5.
-apply absurd_injg_injd with q1; auto with v62.
+apply absurd_injg_injd with q1; auto.
 
 intros x w0 H e1 e2 H0 H1 H2 H3.
 cut
  (Chemin e1 e2 (union_disj q1 q2) (union (injg_d1 q1 d1) (injd_d2 q2 d2))
-    (cons x w0)); auto with v62.
+    (cons x w0)); auto.
 intro.
 cut
  (exists e : Elt,
@@ -754,21 +754,21 @@ cut
     dans e1 (union_disj q1 q2) /\
     dans x alph /\
     dans (couple e1 (couple x e)) (union (injg_d1 q1 d1) (injd_d2 q2 d2)));
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 intros e Ht; elim Ht; clear Ht.
 intros H5 Ht; elim Ht; clear Ht.
 intros H6 Ht; elim Ht; clear Ht; intros H7 H8. 
 cut (dans e (map injgauche q1)).
-2: apply transition_dans_d1 with d1 q2 d2 e1 x; auto with v62.
+2: apply transition_dans_d1 with d1 q2 d2 e1 x; auto.
 intro.
 cut (chemin (first e) (first e2) q1 d1 w0 /\ dans e2 (map injgauche qa1));
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht; intros H10 H11.
-split; auto with v62.
-apply chemin_cons with (first e); auto with v62.
-apply dans_map_injg; auto with v62.
-apply restriction_transition_d1 with q1 q2 d2; auto with v62.
+split; auto.
+apply chemin_cons with (first e); auto.
+apply dans_map_injg; auto.
+apply restriction_transition_d1 with q1 q2 d2; auto.
 Qed.
 
 (*  De meme pour l2...							*)
@@ -800,26 +800,26 @@ intros q1 qd1 qa1 d1 q2 d2.
 simple induction w.
 intros e1 e2 H_aut.
 intros.
-cut (Chemin e1 e2 q1 d1 nil); auto with v62.
+cut (Chemin e1 e2 q1 d1 nil); auto.
 intro.
-cut (dans e1 q1 /\ e1 = e2 :>Elt); auto with v62.
+cut (dans e1 q1 /\ e1 = e2 :>Elt); auto.
 intro Ht; elim Ht; clear Ht.
 intros H3 H4.
-apply chemin_nil; auto with v62.
+apply chemin_nil; auto.
 unfold union_disj in |- *.
 apply union_g.
-replace (couple e1 zero) with (injgauche e1); auto with v62.
-rewrite H4; auto with v62.
+replace (couple e1 zero) with (injgauche e1); auto.
+rewrite H4; auto.
 
 intros x w0 H e1 e2 H_aut.
 intros.
-cut (Chemin e1 e2 q1 d1 (cons x w0)); auto with v62.
+cut (Chemin e1 e2 q1 d1 (cons x w0)); auto.
 intro.
 cut
  (exists e : Elt,
     chemin e e2 q1 d1 w0 /\
     dans e1 q1 /\ dans x alph /\ dans (couple e1 (couple x e)) d1);
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 intros e Ht; elim Ht; clear Ht.
 intros H4 Ht; elim Ht; clear Ht.
@@ -829,33 +829,33 @@ cut (dans e q1).
 intro dans_e_q1.
 
 2: cut (inclus d1 (prodcart q1 (prodcart alph q1))).
-3: apply automate_def1 with qd1 qa1; auto with v62.
+3: apply automate_def1 with qd1 qa1; auto.
 2: intro.
 2: cut (dans (couple e1 (couple x e)) (prodcart q1 (prodcart alph q1))).
-3: apply dans_trans with d1; auto with v62.
+3: apply dans_trans with d1; auto.
 2: intro.
 2: cut (dans e1 q1 /\ dans (couple x e) (prodcart alph q1)).
-3: apply coupl2; auto with v62.
+3: apply coupl2; auto.
 2: intro Ht; elim Ht; clear Ht.
 2: intros H10 H11.
 2: cut (dans x alph /\ dans e q1).  
-3: apply coupl2; auto with v62.
+3: apply coupl2; auto.
 2: intro Ht; elim Ht; clear Ht.
-2: auto with v62.
+2: auto.
 
-apply chemin_cons with (couple e zero); auto with v62.
+apply chemin_cons with (couple e zero); auto.
 
 unfold union_disj in |- *.
 apply union_g.
-replace (couple e1 zero) with (injgauche e1); auto with v62.
+replace (couple e1 zero) with (injgauche e1); auto.
 
 apply union_g.
 unfold injg_d1 in |- *.
-apply imp_dans_tq; auto with v62.
+apply imp_dans_tq; auto.
 apply coupl2_inv.
-replace (couple e1 zero) with (injgauche e1); auto with v62.
-apply coupl2_inv; auto with v62.
-replace (couple e zero) with (injgauche e); auto with v62.
+replace (couple e1 zero) with (injgauche e1); auto.
+apply coupl2_inv; auto.
+replace (couple e zero) with (injgauche e); auto.
 Qed.
 
 (*  De meme pour l2...							*)
@@ -900,53 +900,53 @@ intros H4 Ht; elim Ht; clear Ht.
 intros H5 H6.
 unfold union_disj in H4.
 cut (dans e1 (map injgauche qd1) \/ dans e1 (map injdroite qd2));
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 
 intro H7.
 unfold lunion in |- *.
 left.
 cut (chemin (first e1) (first e2) q1 d1 w /\ dans e2 (map injgauche qa1)).
-2: apply chemin_restriction_1 with qd1 q2 qa2 d2; auto with v62.
+2: apply chemin_restriction_1 with qd1 q2 qa2 d2; auto.
 2: cut (inclus qd1 q1).
-3: apply automate_def2 with qa1 d1; auto with v62.
-2: intro; apply dans_map_trans with qd1; auto with v62.
+3: apply automate_def2 with qa1 d1; auto.
+2: intro; apply dans_map_trans with qd1; auto.
 intro Ht; elim Ht; clear Ht; intros H8 H9.
 unfold eqwordset in H0.
 elim (H0 w).
 intros H10 H11.
 apply H10.
 unfold reconnait in |- *.
-split; auto with v62.
+split; auto.
 exists (first e1).
 exists (first e2).
 split.
-apply dans_map_injg; auto with v62.
+apply dans_map_injg; auto.
 split.
-apply dans_map_injg; auto with v62.
+apply dans_map_injg; auto.
 assumption.
 
 intro H7.
 unfold lunion in |- *.
 right.
 cut (chemin (first e1) (first e2) q2 d2 w /\ dans e2 (map injdroite qa2)).
-2: apply chemin_restriction_2 with qd2 q1 qa1 d1; auto with v62.
+2: apply chemin_restriction_2 with qd2 q1 qa1 d1; auto.
 2: cut (inclus qd2 q2).
-3: apply automate_def2 with qa2 d2; auto with v62.
-2: intro; apply dans_map_trans with qd2; auto with v62.
+3: apply automate_def2 with qa2 d2; auto.
+2: intro; apply dans_map_trans with qd2; auto.
 intro Ht; elim Ht; clear Ht; intros H8 H9.
 unfold eqwordset in H2.
 elim (H2 w).
 intros H10 H11.
 apply H10.
 unfold reconnait in |- *.
-split; auto with v62.
+split; auto.
 exists (first e1).
 exists (first e2).
 split.
-apply dans_map_injd; auto with v62.
+apply dans_map_injd; auto.
 split.
-apply dans_map_injd; auto with v62.
+apply dans_map_injd; auto.
 assumption.
 
 unfold lunion in |- *.
@@ -956,7 +956,7 @@ intro H3.
 unfold eqwordset in H0.
 elim (H0 w).
 intros H4 H5.
-cut (reconnait q1 qd1 qa1 d1 w); auto with v62.
+cut (reconnait q1 qd1 qa1 d1 w); auto.
 intro Ht; elim Ht; clear Ht.
 intros H6 Ht; elim Ht; clear Ht.
 intros e1 Ht; elim Ht; clear Ht.
@@ -964,26 +964,26 @@ intros e2 Ht; elim Ht; clear Ht.
 intros H7 Ht; elim Ht; clear Ht.
 intros H8 H9.
 unfold reconnait in |- *.
-split; auto with v62.
+split; auto.
 exists (couple e1 zero).
 exists (couple e2 zero).
 split.
 unfold union_disj in |- *.
 apply union_g.
-replace (couple e1 zero) with (injgauche e1); auto with v62. 
+replace (couple e1 zero) with (injgauche e1); auto. 
 split.
 unfold union_disj in |- *.
 apply union_g.
-replace (couple e2 zero) with (injgauche e2); auto with v62. 
-apply chemin_extension_1 with qd1 qa1; auto with v62.
-apply dans_trans with qd1; auto with v62.
-apply automate_def2 with qa1 d1; auto with v62.
+replace (couple e2 zero) with (injgauche e2); auto. 
+apply chemin_extension_1 with qd1 qa1; auto.
+apply dans_trans with qd1; auto.
+apply automate_def2 with qa1 d1; auto.
 
 intro H3.
 unfold eqwordset in H2.
 elim (H2 w).
 intros H4 H5.
-cut (reconnait q2 qd2 qa2 d2 w); auto with v62.
+cut (reconnait q2 qd2 qa2 d2 w); auto.
 intro Ht; elim Ht; clear Ht.
 intros H6 Ht; elim Ht; clear Ht.
 intros e1 Ht; elim Ht; clear Ht.
@@ -991,20 +991,20 @@ intros e2 Ht; elim Ht; clear Ht.
 intros H7 Ht; elim Ht; clear Ht.
 intros H8 H9.
 unfold reconnait in |- *.
-split; auto with v62.
+split; auto.
 exists (couple e1 un).
 exists (couple e2 un).
 split.
 unfold union_disj in |- *.
 apply union_d.
-replace (couple e1 un) with (injdroite e1); auto with v62. 
+replace (couple e1 un) with (injdroite e1); auto. 
 split.
 unfold union_disj in |- *.
 apply union_d.
-replace (couple e2 un) with (injdroite e2); auto with v62. 
-apply chemin_extension_2 with qd2 qa2; auto with v62.
-apply dans_trans with qd2; auto with v62.
-apply automate_def2 with qa2 d2; auto with v62.
+replace (couple e2 un) with (injdroite e2); auto. 
+apply chemin_extension_2 with qd2 qa2; auto.
+apply dans_trans with qd2; auto.
+apply automate_def2 with qa2 d2; auto.
 Qed.
 
 (*									*)
@@ -1038,15 +1038,15 @@ split.
 red in |- *.
 split.
 apply inclus_union_disj.
-apply automate_def3 with qd1 d1; auto with v62.
-apply automate_def3 with qd2 d2; auto with v62.
+apply automate_def3 with qd1 d1; auto.
+apply automate_def3 with qd2 d2; auto.
 split.
 apply inclus_union_disj.
-apply automate_def2 with qa1 d1; auto with v62.
-apply automate_def2 with qa2 d2; auto with v62.
+apply automate_def2 with qa1 d1; auto.
+apply automate_def2 with qa2 d2; auto.
 apply d_is_good.
 
-apply lunion_is_reg1; auto with v62.
+apply lunion_is_reg1; auto.
 Qed.
 
 
@@ -1091,48 +1091,48 @@ split.
 unfold union_disj in |- *.
 apply inclus_d2.
 apply map_inclus.
-apply automate_def3 with qd2 d2; auto with v62.
+apply automate_def3 with qd2 d2; auto.
 split.
 unfold union_disj in |- *.
 apply inclus_g2.
 apply map_inclus.
-apply automate_def2 with qa1 d1; auto with v62.
+apply automate_def2 with qa1 d1; auto.
 apply union_inclus.
 unfold pont in |- *.
 unfold inclus in |- *.
 intros.
 cut
  (exists y : Elt, dans y (prodcart qa1 qd2) /\ x = transition_pont y :>Elt).
-2: apply dans_map; auto with v62.
+2: apply dans_map; auto.
 intro Ht; elim Ht; clear Ht.
 intros y Ht; elim Ht; clear Ht; intros H2 H3.
 cut
  (exists y1 : Elt,
     (exists y2 : Elt, dans y1 qa1 /\ dans y2 qd2 /\ y = couple y1 y2 :>Elt)).
-2: apply coupl3; auto with v62.
+2: apply coupl3; auto.
 intro Ht; elim Ht; clear Ht.
 intros y1 Ht; elim Ht; clear Ht.
 intros y2 Ht; elim Ht; clear Ht.
 intros H4 Ht; elim Ht; clear Ht; intros H5 H6.
 cut (x = couple (couple y1 zero) (couple epsilon (couple y2 un)) :>Elt).
 2: rewrite H3.
-2: rewrite H6; auto with v62.
+2: rewrite H6; auto.
 intro H7.
 rewrite H7.
 apply coupl2_inv.
 unfold union_disj in |- *.
 apply union_g.
-replace (couple y1 zero) with (injgauche y1); auto with v62.
+replace (couple y1 zero) with (injgauche y1); auto.
 apply dans_map_inv.
-apply dans_trans with qa1; auto with v62.
-apply automate_def3 with qd1 d1; auto with v62.
-apply coupl2_inv; auto with v62.
+apply dans_trans with qa1; auto.
+apply automate_def3 with qd1 d1; auto.
+apply coupl2_inv; auto.
 unfold union_disj in |- *.
 apply union_d.
-replace (couple y2 un) with (injdroite y2); auto with v62.
+replace (couple y2 un) with (injdroite y2); auto.
 apply dans_map_inv.
-apply dans_trans with qd2; auto with v62.
-apply automate_def2 with qa2 d2; auto with v62.
+apply dans_trans with qd2; auto.
+apply automate_def2 with qa2 d2; auto.
 
 apply union_inclus.
 apply
@@ -1143,14 +1143,14 @@ apply inclus_tq.
 unfold union_disj in |- *.
 apply cart_inclus.
 apply inclus_g.
-apply cart_inclus; auto with v62.
+apply cart_inclus; auto.
 apply
  inclus_trans
   with (prodcart (map injdroite q2) (prodcart alph (map injdroite q2))).
 unfold injd_d2 in |- *.
 apply inclus_tq.
 unfold union_disj in |- *. 
-apply cart_inclus; auto with v62.
+apply cart_inclus; auto.
 Qed.
 
 (*  Si on a une transition (e0,x,e) avec e0 dans (map injgauche q1)	*)
@@ -1167,7 +1167,7 @@ intros.
 cut
  (dans (couple e0 (couple x e)) (pont qa1 qd2) \/
   dans (couple e0 (couple x e)) (union (injg_d1 q1 d1) (injd_d2 q2 d2)));
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 unfold pont in |- *.
 intro.
@@ -1175,26 +1175,26 @@ cut
  (exists y : Elt,
     dans y (prodcart qa1 qd2) /\
     couple e0 (couple x e) = transition_pont y :>Elt).
-	2: apply dans_map; auto with v62.
+	2: apply dans_map; auto.
 intro Ht; elim Ht; clear Ht; intros y Ht; elim Ht; clear Ht; intros H3 H4.
 cut
  (exists y1 : Elt,
     (exists y2 : Elt, dans y1 qa1 /\ dans y2 qd2 /\ y = couple y1 y2 :>Elt)).
-	2: apply coupl3; auto with v62.
+	2: apply coupl3; auto.
 intro Ht; elim Ht; clear Ht; intros y1 Ht; elim Ht; clear Ht; intros y2 Ht;
  elim Ht; clear Ht; intros H5 Ht; elim Ht; clear Ht; 
  intros H6 H7.
 cut (couple e0 (couple x e) = transition_pont (couple y1 y2) :>Elt).
-	2: rewrite <- H7; auto with v62.
+	2: rewrite <- H7; auto.
 unfold transition_pont in |- *.
 intro.
 cut (couple x e = couple epsilon (couple y2 un) :>Elt).
-	2: apply couple_couple_inv2 with e0 (couple y1 zero); auto with v62.
+	2: apply couple_couple_inv2 with e0 (couple y1 zero); auto.
 intro.
 cut (x = epsilon :>Elt).
-	2: apply couple_couple_inv1 with e (couple y2 un); auto with v62.
+	2: apply couple_couple_inv1 with e (couple y2 un); auto.
 intro.
-absurd (dans x alph); auto with v62.
+absurd (dans x alph); auto.
 rewrite H10.
 red in |- *; intro; apply not_dans_epsilon_alph; assumption.
 
@@ -1202,7 +1202,7 @@ intro.
 clear H1.
 cut
  (dans (couple e0 (couple x e)) (injg_d1 q1 d1) \/
-  dans (couple e0 (couple x e)) (injd_d2 q2 d2)); auto with v62.
+  dans (couple e0 (couple x e)) (injd_d2 q2 d2)); auto.
 intro Ht; elim Ht; clear Ht.
 
 unfold injg_d1 in |- *.
@@ -1211,16 +1211,16 @@ cut
  (dans (couple e0 (couple x e))
     (prodcart (map injgauche q1) (prodcart alph (map injgauche q1))) /\
   est_dans_d' d1 (couple e0 (couple x e))).
-	2: apply dans_tq_imp; auto with v62.
+	2: apply dans_tq_imp; auto.
 intro Ht; elim Ht; clear Ht; intros.
 cut
  (dans e0 (map injgauche q1) /\
   dans (couple x e) (prodcart alph (map injgauche q1))).
-	2: apply coupl2; auto with v62.
+	2: apply coupl2; auto.
 intro Ht; elim Ht; clear Ht; intros.
 cut (dans x alph /\ dans e (map injgauche q1)).
-	2: apply coupl2; auto with v62.
-intro Ht; elim Ht; auto with v62.
+	2: apply coupl2; auto.
+intro Ht; elim Ht; auto.
 
 unfold injd_d2 in |- *.
 intro.
@@ -1228,15 +1228,15 @@ cut
  (dans (couple e0 (couple x e))
     (prodcart (map injdroite q2) (prodcart alph (map injdroite q2))) /\
   est_dans_d' d2 (couple e0 (couple x e))).
-	2: apply dans_tq_imp; auto with v62.
+	2: apply dans_tq_imp; auto.
 intro Ht; elim Ht; clear Ht; intros.
 cut
  (dans e0 (map injdroite q2) /\
   dans (couple x e) (prodcart alph (map injdroite q2))).
-	2: apply coupl2; auto with v62.
+	2: apply coupl2; auto.
 intro Ht; elim Ht; clear Ht; intros.
-absurd (dans e0 (map injdroite q2)); auto with v62.
-apply absurd_injg_injd with q1; auto with v62.
+absurd (dans e0 (map injdroite q2)); auto.
+apply absurd_injg_injd with q1; auto.
 Qed.
 
 (*  Si on a la transition (e0,x,e) dans la relation de l'automate	*)
@@ -1255,7 +1255,7 @@ intros.
 cut
  (dans (couple e0 (couple x e)) (pont qa1 qd2) \/
   dans (couple e0 (couple x e)) (union (injg_d1 q1 d1) (injd_d2 q2 d2)));
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 unfold pont in |- *.
 intro.
@@ -1263,26 +1263,26 @@ cut
  (exists y : Elt,
     dans y (prodcart qa1 qd2) /\
     couple e0 (couple x e) = transition_pont y :>Elt).
-	2: apply dans_map; auto with v62.
+	2: apply dans_map; auto.
 intro Ht; elim Ht; clear Ht; intros y Ht; elim Ht; clear Ht; intros H3 H4.
 cut
  (exists y1 : Elt,
     (exists y2 : Elt, dans y1 qa1 /\ dans y2 qd2 /\ y = couple y1 y2 :>Elt)).
-	2: apply coupl3; auto with v62.
+	2: apply coupl3; auto.
 intro Ht; elim Ht; clear Ht; intros y1 Ht; elim Ht; clear Ht; intros y2 Ht;
  elim Ht; clear Ht; intros H5 Ht; elim Ht; clear Ht; 
  intros H6 H7.
 cut (couple e0 (couple x e) = transition_pont (couple y1 y2) :>Elt).
-	2: rewrite <- H7; auto with v62.
+	2: rewrite <- H7; auto.
 unfold transition_pont in |- *.
 intro.
 cut (couple x e = couple epsilon (couple y2 un) :>Elt).
-	2: apply couple_couple_inv2 with e0 (couple y1 zero); auto with v62.
+	2: apply couple_couple_inv2 with e0 (couple y1 zero); auto.
 intro.
 cut (x = epsilon :>Elt).
-	2: apply couple_couple_inv1 with e (couple y2 un); auto with v62.
+	2: apply couple_couple_inv1 with e (couple y2 un); auto.
 intro.
-absurd (dans x alph); auto with v62.
+absurd (dans x alph); auto.
 rewrite H10.
 red in |- *; intro; apply not_dans_epsilon_alph; assumption.
 
@@ -1290,7 +1290,7 @@ intro.
 clear H1.
 cut
  (dans (couple e0 (couple x e)) (injg_d1 q1 d1) \/
-  dans (couple e0 (couple x e)) (injd_d2 q2 d2)); auto with v62.
+  dans (couple e0 (couple x e)) (injd_d2 q2 d2)); auto.
 intro Ht; elim Ht; clear Ht.
 
 unfold injg_d1 in |- *.
@@ -1299,9 +1299,9 @@ cut
  (dans (couple e0 (couple x e))
     (prodcart (map injgauche q1) (prodcart alph (map injgauche q1))) /\
   est_dans_d' d1 (couple e0 (couple x e))).
-	2: apply dans_tq_imp; auto with v62.
+	2: apply dans_tq_imp; auto.
 intro Ht; elim Ht; clear Ht; intros.
-auto with v62.
+auto.
 
 unfold injd_d2 in |- *.
 intro.
@@ -1309,15 +1309,15 @@ cut
  (dans (couple e0 (couple x e))
     (prodcart (map injdroite q2) (prodcart alph (map injdroite q2))) /\
   est_dans_d' d2 (couple e0 (couple x e))).
-	2: apply dans_tq_imp; auto with v62.
+	2: apply dans_tq_imp; auto.
 intro Ht; elim Ht; clear Ht; intros.
 cut
  (dans e0 (map injdroite q2) /\
   dans (couple x e) (prodcart alph (map injdroite q2))).
-	2: apply coupl2; auto with v62.
+	2: apply coupl2; auto.
 intro Ht; elim Ht; clear Ht; intros.
-absurd (dans e0 (map injdroite q2)); auto with v62.
-apply absurd_injg_injd with q1; auto with v62.
+absurd (dans e0 (map injdroite q2)); auto.
+apply absurd_injg_injd with q1; auto.
 Qed.
 
 (*  De meme pour d2...							*)
@@ -1343,7 +1343,7 @@ intros.
 cut
  (dans (couple e0 (couple epsilon e)) (pont qa1 qd2) \/
   dans (couple e0 (couple epsilon e)) (union (injg_d1 q1 d1) (injd_d2 q2 d2)));
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 
 unfold pont in |- *. 
@@ -1352,42 +1352,42 @@ cut
  (exists y : Elt,
     dans y (prodcart qa1 qd2) /\
     couple e0 (couple epsilon e) = transition_pont y :>Elt).
-	2: apply dans_map; auto with v62.
+	2: apply dans_map; auto.
 intro Ht; elim Ht; clear Ht; intros y Ht; elim Ht; clear Ht; intros H3 H4.
 cut
  (exists y1 : Elt,
     (exists y2 : Elt, dans y1 qa1 /\ dans y2 qd2 /\ y = couple y1 y2 :>Elt)).
-	2: apply coupl3; auto with v62.
+	2: apply coupl3; auto.
 intro Ht; elim Ht; clear Ht; intros y1 Ht; elim Ht; clear Ht; intros y2 Ht;
  elim Ht; clear Ht; intros H5 Ht; elim Ht; clear Ht; 
  intros H6 H7.
 cut (couple e0 (couple epsilon e) = transition_pont (couple y1 y2) :>Elt).
-	2: rewrite <- H7; auto with v62.
+	2: rewrite <- H7; auto.
 unfold transition_pont in |- *. 
 intro.
 cut (e0 = couple y1 zero :>Elt).
 	2: apply
      couple_couple_inv1
       with (couple epsilon e) (couple epsilon (couple y2 un)); 
-     auto with v62.
+     auto.
 intro.
 cut (couple epsilon e = couple epsilon (couple y2 un) :>Elt).
-	2: apply couple_couple_inv2 with e0 (couple y1 zero); auto with v62.
+	2: apply couple_couple_inv2 with e0 (couple y1 zero); auto.
 intro.
 cut (e = couple y2 un :>Elt).
-	2: apply couple_couple_inv2 with epsilon epsilon; auto with v62.
+	2: apply couple_couple_inv2 with epsilon epsilon; auto.
 intro.
 split.
-replace e0 with (couple y1 zero); auto with v62.
-replace (couple y1 zero) with (injgauche y1); auto with v62.
-replace e with (couple y2 un); auto with v62.
-replace (couple y2 un) with (injdroite y2); auto with v62.
+replace e0 with (couple y1 zero); auto.
+replace (couple y1 zero) with (injgauche y1); auto.
+replace e with (couple y2 un); auto.
+replace (couple y2 un) with (injdroite y2); auto.
 
 intro.
 cut
  (dans (couple e0 (couple epsilon e)) (injg_d1 q1 d1) \/
   dans (couple e0 (couple epsilon e)) (injd_d2 q2 d2)); 
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 
 unfold injg_d1 in |- *.
@@ -1396,17 +1396,17 @@ cut
  (dans (couple e0 (couple epsilon e))
     (prodcart (map injgauche q1) (prodcart alph (map injgauche q1))) /\
   est_dans_d' d1 (couple e0 (couple epsilon e))).
-	2: apply dans_tq_imp; auto with v62.
+	2: apply dans_tq_imp; auto.
 intro Ht; elim Ht; clear Ht; intros.
 cut
  (dans e0 (map injgauche q1) /\
   dans (couple epsilon e) (prodcart alph (map injgauche q1))).
-	2: apply coupl2; auto with v62.
+	2: apply coupl2; auto.
 intro Ht; elim Ht; clear Ht; intros.
 cut (dans epsilon alph /\ dans e (map injgauche q1)).
-	2: apply coupl2; auto with v62.
+	2: apply coupl2; auto.
 intro Ht; elim Ht; clear Ht; intros.
-absurd (dans epsilon alph); auto with v62.
+absurd (dans epsilon alph); auto.
 red in |- *; intro; apply not_dans_epsilon_alph; assumption.
 
 unfold injd_d2 in |- *.
@@ -1415,17 +1415,17 @@ cut
  (dans (couple e0 (couple epsilon e))
     (prodcart (map injdroite q2) (prodcart alph (map injdroite q2))) /\
   est_dans_d' d2 (couple e0 (couple epsilon e))).
-	2: apply dans_tq_imp; auto with v62.
+	2: apply dans_tq_imp; auto.
 intro Ht; elim Ht; clear Ht; intros.
 cut
  (dans e0 (map injdroite q2) /\
   dans (couple epsilon e) (prodcart alph (map injdroite q2))).
-	2: apply coupl2; auto with v62.
+	2: apply coupl2; auto.
 intro Ht; elim Ht; clear Ht; intros.
 cut (dans epsilon alph /\ dans e (map injdroite q2)).
-	2: apply coupl2; auto with v62.
+	2: apply coupl2; auto.
 intro Ht; elim Ht; clear Ht; intros.
-absurd (dans epsilon alph); auto with v62.
+absurd (dans epsilon alph); auto.
 red in |- *; intro; apply not_dans_epsilon_alph; assumption.
 Qed.
 
@@ -1441,12 +1441,12 @@ cut
  (exists y : Elt,
     dans y (prodcart qa1 qd2) /\
     couple e1 (couple x e0) = transition_pont y :>Elt).
-2: apply dans_map; auto with v62.
+2: apply dans_map; auto.
 intro Ht; elim Ht; clear Ht; intros y Ht; elim Ht; clear Ht; intros H0 H1.
 cut
  (exists y1 : Elt,
     (exists y2 : Elt, dans y1 qa1 /\ dans y2 qd2 /\ y = couple y1 y2 :>Elt)).
-2: apply coupl3; auto with v62.
+2: apply coupl3; auto.
 intro Ht; elim Ht; clear Ht; intros y1 Ht; elim Ht; clear Ht; intros y2 Ht;
  elim Ht; clear Ht; intros H2 Ht; elim Ht; clear Ht; 
  intros H3 H4.
@@ -1474,22 +1474,22 @@ elim H; clear H.
 
 intros.
 apply chemin_nil.
-apply dans_map_injd; auto with v62.
-apply (f_equal (A:=Elt) (B:=Elt)); auto with v62.
+apply dans_map_injd; auto.
+apply (f_equal (A:=Elt) (B:=Elt)); auto.
 
 intros e1 e0 e2 x w H H0 H1 H2 H3 H4 H5.
-apply chemin_cons with (first e0); auto with v62.
-apply H0; auto with v62.
+apply chemin_cons with (first e0); auto.
+apply H0; auto.
 cut
  (dans (couple e1 (couple x e0)) (pont qa1 qd2) \/
   dans (couple e1 (couple x e0)) (union (injg_d1 q1 d1) (injd_d2 q2 d2)));
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 	intro.
 	cut (x = epsilon :>Elt).
-	2: apply dans_pont_imp_epsilon with qa1 qd2 e1 e0; auto with v62.
+	2: apply dans_pont_imp_epsilon with qa1 qd2 e1 e0; auto.
 	intro.
-	absurd (dans x alph); auto with v62.
+	absurd (dans x alph); auto.
 	rewrite H7.
 	red in |- *; intro; apply not_dans_epsilon_alph; assumption.
 
@@ -1497,7 +1497,7 @@ intro Ht; elim Ht; clear Ht.
 	cut
   (dans (couple e1 (couple x e0)) (injg_d1 q1 d1) \/
    dans (couple e1 (couple x e0)) (injd_d2 q2 d2)); 
-  auto with v62.
+  auto.
 	intro Ht; elim Ht; clear Ht.
 
 	unfold injg_d1 in |- *.
@@ -1506,15 +1506,15 @@ intro Ht; elim Ht; clear Ht.
   (dans (couple e1 (couple x e0))
      (prodcart (map injgauche q1) (prodcart alph (map injgauche q1))) /\
    est_dans_d' d1 (couple e1 (couple x e0))).
-	2: apply dans_tq_imp; auto with v62.
+	2: apply dans_tq_imp; auto.
 	intro Ht; elim Ht; clear Ht; intros.
 	cut
   (dans e1 (map injgauche q1) /\
    dans (couple x e0) (prodcart alph (map injgauche q1))).
-	2: apply coupl2; auto with v62.
+	2: apply coupl2; auto.
 	intro Ht; elim Ht; clear Ht; intros.
-	absurd (dans e1 (map injdroite q2)); auto with v62.
-	apply absurd_injg_injd with q1; auto with v62.
+	absurd (dans e1 (map injdroite q2)); auto.
+	apply absurd_injg_injd with q1; auto.
 
 	unfold injd_d2 in |- *.
 	intro.
@@ -1522,28 +1522,28 @@ intro Ht; elim Ht; clear Ht.
   (dans (couple e1 (couple x e0))
      (prodcart (map injdroite q2) (prodcart alph (map injdroite q2))) /\
    est_dans_d' d2 (couple e1 (couple x e0))).
-	2: apply dans_tq_imp; auto with v62.
+	2: apply dans_tq_imp; auto.
 	intro Ht; elim Ht; clear Ht; intros.
 	cut
   (dans e1 (map injdroite q2) /\
    dans (couple x e0) (prodcart alph (map injdroite q2))).
-	2: apply coupl2; auto with v62.
+	2: apply coupl2; auto.
 	intro Ht; elim Ht; clear Ht; intros.
 	cut (dans x alph /\ dans e0 (map injdroite q2)).
-	2: apply coupl2; auto with v62.
-	intro Ht; elim Ht; auto with v62.
+	2: apply coupl2; auto.
+	intro Ht; elim Ht; auto.
 
-	apply dans_map_injd; auto with v62.
+	apply dans_map_injd; auto.
 	
-	apply transition_a_droite_2 with q1 qa1 d1 q2 qd2; auto with v62.
+	apply transition_a_droite_2 with q1 qa1 d1 q2 qd2; auto.
 
 intros e1 e0 e2 w H H0 H1 H2 H3 H4.
 cut (dans e1 (map injgauche qa1) /\ dans e0 (map injdroite qd2)).
-2: apply transition_dans_pont with q1 d1 q2 d2; auto with v62.
+2: apply transition_dans_pont with q1 d1 q2 d2; auto.
 intro Ht; elim Ht; clear Ht.
 intros.
-absurd (dans e1 (map injdroite q2)); auto with v62.
-apply absurd_injg_injd with qa1; auto with v62.
+absurd (dans e1 (map injdroite q2)); auto.
+apply absurd_injg_injd with qa1; auto.
 Qed.
 
 
@@ -1571,13 +1571,13 @@ intros q1 qd1 qa1 d1 q2 qd2 qa2 d2 e1 e2 w H_aut1 H_aut2 H.
 elim H.
 
 intros e0 e3 H0 H1 H2 H3.
-absurd (dans e3 (map injdroite q2)); auto with v62.
+absurd (dans e3 (map injdroite q2)); auto.
 apply absurd_injg_injd with q1.
 rewrite <- H1; assumption.
 
 intros e0 e e3 x w0 H0 H1 H2 H3 H4 H5 H6.
 cut (dans e (map injgauche q1)).
-	2: apply transition_a_gauche with qa1 d1 q2 qd2 d2 e0 x; auto with v62.
+	2: apply transition_a_gauche with qa1 d1 q2 qd2 d2 e0 x; auto.
 intro H7.
 elim (H1 H7 H6); clear H1.
 intros x1 Ht; elim Ht; clear Ht; intros x2 Ht; elim Ht; clear Ht;
@@ -1592,10 +1592,10 @@ exists w2.
 split; [ assumption | split; [ assumption | split ] ].
 	2: split.
 	2: assumption.
-	2: rewrite H12; auto with v62.
-apply chemin_cons with (first e); auto with v62.
-apply dans_map_injg; auto with v62.
-apply transition_a_gauche_2 with q1 qa1 q2 qd2 d2; auto with v62.
+	2: rewrite H12; auto.
+apply chemin_cons with (first e); auto.
+apply dans_map_injg; auto.
+apply transition_a_gauche_2 with q1 qa1 q2 qd2 d2; auto.
 
 intros e0 e e3 w0 H0 H1 H2 H3 H4 H5.
 clear H1.
@@ -1604,20 +1604,20 @@ exists (first e).
 exists nil.
 exists w0.
 cut (dans e0 (map injgauche qa1) /\ dans e (map injdroite qd2)).
-	2: apply transition_dans_pont with q1 d1 q2 d2; auto with v62.
+	2: apply transition_dans_pont with q1 d1 q2 d2; auto.
 intro Ht; elim Ht; clear Ht; intros H6 H7.
 split; [ apply dans_map_injg; assumption | split ].
 apply dans_map_injd; assumption.
 
 split.
-apply chemin_nil; auto with v62.
+apply chemin_nil; auto.
 apply dans_trans with qa1.
-apply dans_map_injg; auto with v62.
-apply automate_def3 with qd1 d1; auto with v62.
-split; auto with v62.
-apply chemin_A_chemin_2 with q1 qa1 d1 qd2; auto with v62.
-apply dans_map_trans with qd2; auto with v62.
-apply automate_def2 with qa2 d2; auto with v62.
+apply dans_map_injg; auto.
+apply automate_def3 with qd1 d1; auto.
+split; auto.
+apply chemin_A_chemin_2 with q1 qa1 d1 qd2; auto.
+apply dans_map_trans with qd2; auto.
+apply automate_def2 with qa2 d2; auto.
 Qed.
 
 
@@ -1640,57 +1640,57 @@ Lemma reconnait_Append :
 intros q1 qd1 qa1 d1 q2 qd2 qa2 d2 w2 x1 x2 e2.
 simple induction w1.
 intros e1 H_aut1 H_aut2 H H0 H1 H2 H3.
-cut (Chemin e1 x1 q1 d1 nil); auto with v62.
+cut (Chemin e1 x1 q1 d1 nil); auto.
 intro H4.
-cut (dans e1 q1 /\ e1 = x1 :>Elt); auto with v62.
+cut (dans e1 q1 /\ e1 = x1 :>Elt); auto.
 intro Ht; elim Ht; clear Ht; intros H5 H6.
-replace (Append nil w2) with w2; auto with v62.
+replace (Append nil w2) with w2; auto.
 apply chemin_A_epsilon with (couple x2 un).
 apply chemin_A_d1_d2 with (union (injg_d1 q1 d1) (injd_d2 q2 d2));
- auto with v62.
+ auto.
 apply chemin_chemin_A.
-apply chemin_extension_2 with qd2 qa2; auto with v62.
-apply dans_trans with qd2; auto with v62.
-apply automate_def2 with qa2 d2; auto with v62.
+apply chemin_extension_2 with qd2 qa2; auto.
+apply dans_trans with qd2; auto.
+apply automate_def2 with qa2 d2; auto.
 
-replace (couple e1 zero) with (injgauche e1); auto with v62.
+replace (couple e1 zero) with (injgauche e1); auto.
 unfold union_disj in |- *.
 apply union_g.
-apply dans_map_inv; auto with v62.
+apply dans_map_inv; auto.
 
 apply union_g.
 unfold pont in |- *.
 rewrite H6.
 replace (couple (couple x1 zero) (couple epsilon (couple x2 un))) with
- (transition_pont (couple x1 x2)); auto with v62.
+ (transition_pont (couple x1 x2)); auto.
 
 intros x w H e1 H0 H1 H2 H3 H4 H5 H6.
-replace (Append (cons x w) w2) with (cons x (Append w w2)); auto with v62.
-cut (Chemin e1 x1 q1 d1 (cons x w)); auto with v62.
+replace (Append (cons x w) w2) with (cons x (Append w w2)); auto.
+cut (Chemin e1 x1 q1 d1 (cons x w)); auto.
 intro H7.
 cut
  (exists e : Elt,
     chemin e x1 q1 d1 w /\
     dans e1 q1 /\ dans x alph /\ dans (couple e1 (couple x e)) d1);
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht; intros e Ht; elim Ht; clear Ht; intros H8 Ht;
  elim Ht; clear Ht; intros H9 Ht; elim Ht; clear Ht; 
  intros H10 H11.
-apply chemin_A_cons with (couple e zero); auto with v62.
+apply chemin_A_cons with (couple e zero); auto.
 	unfold union_disj in |- *.
 	apply union_g.
-	replace (couple e1 zero) with (injgauche e1); auto with v62.
+	replace (couple e1 zero) with (injgauche e1); auto.
 
 	apply union_d.
 	apply union_g.
 	unfold injg_d1 in |- *.
-	apply imp_dans_tq; auto with v62.
+	apply imp_dans_tq; auto.
 	apply coupl2_inv.
-	replace (couple e1 zero) with (injgauche e1); auto with v62.
-	apply coupl2_inv; auto with v62.
-	replace (couple e zero) with (injgauche e); auto with v62.
-	apply dans_map_inv; auto with v62.
-	apply dans_e1_q with d1 w x1; auto with v62.
+	replace (couple e1 zero) with (injgauche e1); auto.
+	apply coupl2_inv; auto.
+	replace (couple e zero) with (injgauche e); auto.
+	apply dans_map_inv; auto.
+	apply dans_e1_q with d1 w x1; auto.
 Qed.
 
 
@@ -1730,11 +1730,11 @@ cut
              dans x2 qd2 /\
              chemin (first e1) x1 q1 d1 w1 /\
              chemin x2 (first e2) q2 d2 w2 /\ w = Append w1 w2 :>Word)))).
-2: apply par_le_pont with qd1 qa2; auto with v62.
-	2: apply dans_map_trans with qd1; auto with v62.
-	2: apply automate_def2 with qa1 d1; auto with v62.
-	2: apply dans_map_trans with qa2; auto with v62.
-	2: apply automate_def3 with qd2 d2; auto with v62.
+2: apply par_le_pont with qd1 qa2; auto.
+	2: apply dans_map_trans with qd1; auto.
+	2: apply automate_def2 with qa1 d1; auto.
+	2: apply dans_map_trans with qa2; auto.
+	2: apply automate_def3 with qd2 d2; auto.
 intros Ht; elim Ht; clear Ht.
 intros x1 Ht; elim Ht; clear Ht.
 intros x2 Ht; elim Ht; clear Ht.
@@ -1754,11 +1754,11 @@ split.
 	unfold reconnait in |- *.
 	split.
 	apply Append_inmonoid_g with w2.
-	rewrite <- H11; auto with v62.
+	rewrite <- H11; auto.
 	exists (first e1).
 	exists x1.
-	split; auto with v62.
-	apply dans_map_injg; auto with v62.
+	split; auto.
+	apply dans_map_injg; auto.
 
 	split.
 	unfold eqwordset in H2; elim (H2 w2).
@@ -1767,11 +1767,11 @@ split.
 	unfold reconnait in |- *.
 	split.
 	apply Append_inmonoid_d with w1.
-	rewrite <- H11; auto with v62.
+	rewrite <- H11; auto.
 	exists x2.
 	exists (first e2).
-	split; auto with v62.
-	split; [ apply dans_map_injd; auto with v62 | auto with v62 ].
+	split; auto.
+	split; [ apply dans_map_injd; auto | auto ].
 
 	assumption.
 
@@ -1784,12 +1784,12 @@ intros H4 H5.
 cut (reconnait q1 qd1 qa1 d1 w1).
 	2: unfold eqwordset in H0.
 	2: elim (H0 w1); intros.
-	2: auto with v62.
+	2: auto.
 intro H6.
 cut (reconnait q2 qd2 qa2 d2 w2).
 	2: unfold eqwordset in H2.
 	2: elim (H2 w2); intros.
-	2: auto with v62.
+	2: auto.
 intro H7.
 rewrite H5.
 elim H6.
@@ -1802,14 +1802,14 @@ intros H12 Ht; elim Ht; clear Ht; intros x2 Ht; elim Ht; clear Ht;
  clear Ht; intros H14 H15.
 unfold reconnait_A in |- *.
 split.
-	apply inmonoid_Append; auto with v62.
+	apply inmonoid_Append; auto.
 exists (couple e1 zero).
 exists (couple e2 un).
 split.
-	replace (couple e1 zero) with (injgauche e1); auto with v62.
+	replace (couple e1 zero) with (injgauche e1); auto.
 split.
-	replace (couple e2 un) with (injdroite e2); auto with v62.
-apply reconnait_Append with qd1 qa2 x1 x2; auto with v62.
+	replace (couple e2 un) with (injdroite e2); auto.
+apply reconnait_Append with qd1 qa2 x1 x2; auto.
 Qed.
 
 (*  Si les langages l1 et l2 sont reguliers alors l1.l2 est aussi	*)
@@ -1839,9 +1839,9 @@ exists (map injdroite qa2).
 exists (union (pont qa1 qd2) (union (injg_d1 q1 d1) (injd_d2 q2 d2))).
 split.
 
-apply automate_lconc_isgood; auto with v62.
+apply automate_lconc_isgood; auto.
 
-apply lconc_is_reg1; auto with v62.
+apply lconc_is_reg1; auto.
 Qed.
 
 
@@ -1868,22 +1868,22 @@ apply union_inclus.
 cut (inclus d (prodcart q (prodcart alph q))).
 2: apply automate_def1 with (singleton g0) qa; assumption.
 intro.
-apply inclus_trans with (prodcart q (prodcart alph q)); auto with v62.
+apply inclus_trans with (prodcart q (prodcart alph q)); auto.
 
 unfold delta in |- *.
 unfold inclus in |- *.
 intros.
 cut (exists y : Elt, dans y qa /\ x = transition_back g0 y :>Elt).
-2: apply dans_map; auto with v62.
+2: apply dans_map; auto.
 intro Ht; elim Ht; clear Ht; intros y Ht; elim Ht; clear Ht; intros H1 H2.
 rewrite H2.
 unfold transition_back in |- *.
 apply coupl2_inv.
-apply dans_trans with qa; auto with v62.
-apply automate_def3 with (singleton g0) d; auto with v62.
-apply coupl2_inv; auto with v62.
-apply dans_trans with (singleton g0); auto with v62.
-apply automate_def2 with qa d; auto with v62.
+apply dans_trans with qa; auto.
+apply automate_def3 with (singleton g0) d; auto.
+apply coupl2_inv; auto.
+apply dans_trans with (singleton g0); auto.
+apply automate_def2 with qa d; auto.
 Qed.
 
 
@@ -1903,7 +1903,7 @@ unfold fun_d_dstar in |- *.
 intro.
 cut
  (dans (couple e0 (couple x e)) d \/
-  dans (couple e0 (couple x e)) (delta g0 qa)); auto with v62.
+  dans (couple e0 (couple x e)) (delta g0 qa)); auto.
 intro Ht; elim Ht; clear Ht.
 
 intro; assumption.
@@ -1913,16 +1913,16 @@ intro.
 cut
  (exists y : Elt,
     dans y qa /\ couple e0 (couple x e) = transition_back g0 y :>Elt).
-2: apply dans_map; auto with v62.
+2: apply dans_map; auto.
 intro Ht; elim Ht; clear Ht; intros y Ht; elim Ht; clear Ht; intros.
 unfold transition_back in H4.
 cut (e0 = y :>Elt /\ couple x e = couple epsilon g0 :>Elt).
-2: apply equal_couple; auto with v62.
+2: apply equal_couple; auto.
 intro Ht; elim Ht; clear Ht; intros.
 cut (x = epsilon :>Elt /\ e = g0 :>Elt).
-2: apply equal_couple; auto with v62.
+2: apply equal_couple; auto.
 intro Ht; elim Ht; clear Ht; intros.
-absurd (dans x alph); auto with v62. 
+absurd (dans x alph); auto. 
 rewrite H7.
 red in |- *; intro; apply not_dans_epsilon_alph; assumption.
 Qed.
@@ -1942,7 +1942,7 @@ unfold fun_d_dstar in H0.
 cut
  (dans (couple e0 (couple epsilon e)) d \/
   dans (couple e0 (couple epsilon e)) (delta g0 qa)); 
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 
 intro.
@@ -1950,15 +1950,15 @@ cut (inclus d (prodcart q (prodcart alph q))).
 2: apply automate_def1 with (singleton g0) qa; assumption.
 intro.
 cut (dans (couple e0 (couple epsilon e)) (prodcart q (prodcart alph q))).
-2: apply dans_trans with d; auto with v62.
+2: apply dans_trans with d; auto.
 intro.
 cut (dans e0 q /\ dans (couple epsilon e) (prodcart alph q)).
-2: apply coupl2; auto with v62.
+2: apply coupl2; auto.
 intro Ht; elim Ht; clear Ht; intros.
 cut (dans epsilon alph /\ dans e q).
-2: apply coupl2; auto with v62.
+2: apply coupl2; auto.
 intro Ht; elim Ht; clear Ht; intros.
-absurd (dans epsilon alph); auto with v62.
+absurd (dans epsilon alph); auto.
 red in |- *; intro; apply not_dans_epsilon_alph; assumption.
 
 unfold delta in |- *.
@@ -1966,17 +1966,17 @@ intro.
 cut
  (exists y : Elt,
     dans y qa /\ couple e0 (couple epsilon e) = transition_back g0 y :>Elt).
-2: apply dans_map; auto with v62.
+2: apply dans_map; auto.
 intro Ht; elim Ht; clear Ht; intros y Ht; elim Ht; clear Ht; intros.
 unfold transition_back in H3.
 cut (e0 = y :>Elt /\ couple epsilon e = couple epsilon g0 :>Elt).
-2: apply equal_couple; auto with v62.
+2: apply equal_couple; auto.
 intro Ht; elim Ht; clear Ht; intros.
 cut (epsilon = epsilon :>Elt /\ e = g0 :>Elt).
-2: apply equal_couple; auto with v62.
+2: apply equal_couple; auto.
 intro Ht; elim Ht; clear Ht; intros.
 rewrite H4.
-auto with v62.
+auto.
 Qed.
 
 (*									*)
@@ -1991,23 +1991,23 @@ Lemma chemin_g0_g0 :
 intros q qa d g0 w0 H_aut H_g0.
 generalize w0; clear w0; simple induction w0.
 
-auto with v62.
+auto.
 
 intros x w H H0.
-cut (Chemin g0 g0 q d (cons x w)); auto with v62.
+cut (Chemin g0 g0 q d (cons x w)); auto.
 intro.
 cut
  (exists e : Elt,
     chemin e g0 q d w /\
     dans g0 q /\ dans x alph /\ dans (couple g0 (couple x e)) d);
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht; intros e Ht; elim Ht; clear Ht; intros H2 Ht;
  elim Ht; clear Ht; intros H3 Ht; elim Ht; clear Ht; 
  intros H4 H5.
 cut (x = epsilon :>Elt).
 2: apply (H_g0 e x); assumption.
 intro.
-absurd (dans x alph); auto with v62.
+absurd (dans x alph); auto.
 rewrite H6.
 red in |- *; intro; apply not_dans_epsilon_alph; assumption.
 Qed.
@@ -2038,18 +2038,18 @@ elim H0.
 
 intros.
 left.
-apply chemin_nil; auto with v62.
+apply chemin_nil; auto.
 
 intros e0 e e3 x w0 H1 H2 H3 H4 H5 H6.
 cut (dans (couple e0 (couple x e)) d).
-2: apply transition_dans_l with q qa g0; auto with v62.
+2: apply transition_dans_l with q qa g0; auto.
 intro.
 elim H2; clear H2.
 3: assumption.
 
 	intro.
 	left.
-	apply chemin_cons with e; auto with v62.
+	apply chemin_cons with e; auto.
 
 	intro Ht; elim Ht; clear Ht; intros x1 Ht; elim Ht; clear Ht; intros w1 Ht;
   elim Ht; clear Ht; intros w2 Ht; elim Ht; clear Ht; 
@@ -2060,15 +2060,15 @@ elim H2; clear H2.
 	exists (cons x w1).
 	exists w2.
 	split.
-	apply chemin_cons with e; auto with v62.
+	apply chemin_cons with e; auto.
 	split; [ assumption | split ].
 	assumption.
-	replace (Append (cons x w1) w2) with (cons x (Append w1 w2)); auto with v62.
+	replace (Append (cons x w1) w2) with (cons x (Append w1 w2)); auto.
 
 intros e0 e e3 w0 H1 H2 H3 H4 H5.
 right.
 cut (dans e0 qa /\ e = g0 :>Elt).
-2: apply transition_par_epsilon with q d; auto with v62.
+2: apply transition_par_epsilon with q d; auto.
 intro Ht; elim Ht; clear Ht; intros.
 elim H2; clear H2.
 3: assumption.
@@ -2083,13 +2083,13 @@ elim H2; clear H2.
 	exists nil.
 	exists nil.
 	split.
-	apply chemin_nil; auto with v62.
+	apply chemin_nil; auto.
 	split; [ assumption | split ].
 	unfold lstar in |- *.
 	exists 0.
 	unfold lpuiss in |- *.
-	unfold lword in |- *; auto with v62.
-	rewrite H8; auto with v62.
+	unfold lword in |- *; auto.
+	rewrite H8; auto.
 
 	intro Ht; elim Ht; clear Ht; intros x1 Ht; elim Ht; clear Ht; intros w1 Ht;
   elim Ht; clear Ht; intros w2 Ht; elim Ht; clear Ht; 
@@ -2099,9 +2099,9 @@ elim H2; clear H2.
 	exists nil.
 	exists (Append w1 w2).
 	split.
-	apply chemin_nil; auto with v62.
+	apply chemin_nil; auto.
 	split; [ assumption | split ].
-	2: replace (Append nil (Append w1 w2)) with (Append w1 w2); auto with v62.
+	2: replace (Append nil (Append w1 w2)) with (Append w1 w2); auto.
 	
 	elim H10.
 	intros n H12.
@@ -2112,16 +2112,16 @@ elim H2; clear H2.
 	exists w1.
 	exists w2.
 	split.
-		2: split; [ assumption | auto with v62 ].
+		2: split; [ assumption | auto ].
 	unfold eqwordset in H_eq.
 	elim (H_eq w1); intros.
 	apply H2.
 	unfold reconnait in |- *.
 	split.
-	apply (Cheminmonoid w1 q (singleton g0) qa d H e x1 H8); auto with v62.
+	apply (Cheminmonoid w1 q (singleton g0) qa d H e x1 H8); auto.
 	exists e.
 	exists x1.
-	split; [ rewrite H7; auto with v62 | split; [ assumption | assumption ] ].
+	split; [ rewrite H7; auto | split; [ assumption | assumption ] ].
 Qed.
 
 (*									*)
@@ -2146,16 +2146,16 @@ cut
         (exists w2 : Word,
            chemin e1 e q d w1 /\
            dans e qa /\ lstar l w2 /\ w = Append w1 w2 :>Word)))).
-2: apply lstar_is_reg2_bis with g0; auto with v62.
+2: apply lstar_is_reg2_bis with g0; auto.
 intro Ht; elim Ht; clear Ht.
 
 intro.
-cut (e1 = g0 :>Elt); auto with v62.
-cut (e2 = g0 :>Elt); auto with v62.
+cut (e1 = g0 :>Elt); auto.
+cut (e2 = g0 :>Elt); auto.
 intros.
 cut (chemin g0 g0 q d w).
-2: cut (chemin e1 e2 q d w); auto with v62.
-2: rewrite H7; rewrite H8; auto with v62.
+2: cut (chemin e1 e2 q d w); auto.
+2: rewrite H7; rewrite H8; auto.
 intro.
 cut (w = nil :>Word).
 2: apply (H0 w); assumption.
@@ -2164,7 +2164,7 @@ rewrite H10.
 unfold lstar in |- *.
 exists 0.
 unfold lpuiss in |- *.
-unfold lword in |- *; auto with v62.
+unfold lword in |- *; auto.
 
 intro Ht; elim Ht; clear Ht; intros e Ht; elim Ht; clear Ht; intros w1 Ht;
  elim Ht; clear Ht; intros w2 Ht; elim Ht; clear Ht; 
@@ -2185,10 +2185,10 @@ elim (H1 w1); intros.
 apply H11.
 unfold reconnait in |- *.
 split.
-apply (Cheminmonoid w1 q (singleton g0) qa d H e1 e H6); auto with v62.
+apply (Cheminmonoid w1 q (singleton g0) qa d H e1 e H6); auto.
 exists e1.
 exists e.
-auto with v62.
+auto.
 Qed.
 
 (*									*)
@@ -2198,7 +2198,7 @@ Qed.
 Lemma lstar_is_reg : forall l : wordset, isregular l -> isregular (lstar l).
 intros l H.
 cut (isregular_D l).
-2: apply isregular_isregular_D; auto with v62.
+2: apply isregular_isregular_D; auto.
 clear H; intro H; elim H; clear H.
   intros q H; elim H; clear H; intros g0 H; elim H; clear H; intros qa H;
    elim H; clear H; intros d H; elim H; clear H.
@@ -2222,23 +2222,23 @@ unfold eqwordset in |- *.
 intro w.
 split.
 
-intro; apply lstar_is_reg1 with q qa d g0; auto with v62.
+intro; apply lstar_is_reg1 with q qa d g0; auto.
 
-intro; pattern w in |- *; apply induction_star with l; auto with v62.
+intro; pattern w in |- *; apply induction_star with l; auto.
 simple induction n.
 unfold lpuiss in |- *.                         
 unfold lword in |- *.
 intros.
 rewrite <- H0.
 unfold reconnait_A in |- *.
-split; auto with v62.
+split; auto.
 exists g0.
 exists g0.
-split; [ auto with v62 | split ].
-auto with v62.
-apply chemin_A_nil; auto with v62.
-apply dans_trans with (singleton g0); auto with v62.
-apply automate_def2 with qa d; auto with v62.
+split; [ auto | split ].
+auto.
+apply chemin_A_nil; auto.
+apply dans_trans with (singleton g0); auto.
+apply automate_def2 with qa d; auto.
 
 intros y H1 w0.
 change
@@ -2250,11 +2250,11 @@ intros Ht; elim Ht; clear Ht; intros w1 Ht; elim Ht; clear Ht; intros w2 Ht;
  elim Ht; clear Ht; intros H2 Ht; elim Ht; clear Ht; 
  intros H3 H4.
 cut (reconnait_A q (singleton g0) (singleton g0) (fun_d_dstar g0 qa d) w2);
- auto with v62.
+ auto.
 intro H5.
 unfold eqwordset in H_eq.
 elim (H_eq w1); intros H6 H7.
-cut (reconnait q (singleton g0) qa d w1); auto with v62.
+cut (reconnait q (singleton g0) qa d w1); auto.
 intro H8.
 clear H6 H7 H1 H_eq.
 elim H8; clear H8; intros H8 Ht; elim Ht; clear Ht; intros e1 Ht; elim Ht;
@@ -2267,7 +2267,7 @@ unfold reconnait_A in |- *.
 split.
 
 	rewrite H4.
-	apply inmonoid_Append; auto with v62.
+	apply inmonoid_Append; auto.
 
 exists e1.
 exists e4.
@@ -2276,20 +2276,20 @@ assumption.
 rewrite H4.
 apply chemin_Append with e2.
 apply chemin_A_d1_d2 with d.
-apply chemin_chemin_A; auto with v62.
+apply chemin_chemin_A; auto.
 unfold fun_d_dstar in |- *.
 apply inclus_g.
-apply chemin_A_epsilon with e3; auto with v62.
-apply dans_trans with qa; auto with v62.
-apply automate_def3 with (singleton g0) d; auto with v62.
+apply chemin_A_epsilon with e3; auto.
+apply dans_trans with qa; auto.
+apply automate_def3 with (singleton g0) d; auto.
 unfold fun_d_dstar in |- *.
 apply union_d.
 unfold delta in |- *.
-cut (e3 = g0 :>Elt); auto with v62.
+cut (e3 = g0 :>Elt); auto.
 intro H16.
 rewrite H16.
 replace (couple e2 (couple epsilon g0)) with (transition_back g0 e2);
- auto with v62.
+ auto.
 Qed.
 
 
@@ -2303,8 +2303,8 @@ Qed.
 Lemma rat_is_reg : forall L : wordset, isrationnal L -> isregular L.
 intros L H.
 elim H.
-intros; apply lword_is_reg; auto with v62.
-intros; apply lunion_is_reg; auto with v62.
-intros; apply lconc_is_reg; auto with v62.
-intros; apply lstar_is_reg; auto with v62.
+intros; apply lword_is_reg; auto.
+intros; apply lunion_is_reg; auto.
+intros; apply lconc_is_reg; auto.
+intros; apply lstar_is_reg; auto.
 Qed.

--- a/Reg.v
+++ b/Reg.v
@@ -61,7 +61,7 @@ Lemma automate_def1 :
 intros q qd qa d H.
 elim H.
 intros H1 H0; elim H0; clear H0.
-auto with v62.
+auto.
 Qed.
 
 Lemma automate_def2 :
@@ -69,7 +69,7 @@ Lemma automate_def2 :
 intros q qd qa d H.
 elim H.
 intros H1 H0; elim H0; clear H0.
-auto with v62.
+auto.
 Qed.
 
 Lemma automate_def3 :
@@ -77,7 +77,7 @@ Lemma automate_def3 :
 intros q qd qa d H.
 elim H.
 intros H1 H0; elim H0; clear H0.
-auto with v62.
+auto.
 Qed.
 
 (*									*)
@@ -97,7 +97,7 @@ Inductive chemin : Elt -> Elt -> Ensf -> Ensf -> Word -> Prop :=
       dans a alph ->
       dans (couple e (couple a e1)) d -> chemin e e2 q d (cons a w).
 
-Hint Resolve chemin_nil: v62.
+Hint Resolve chemin_nil.
 
 (*  On definit le meme predicat d'une autre facon, qui sera plus utile	*)
 (*  par la suite							*)
@@ -121,23 +121,23 @@ Lemma Chemin_chemin :
 intros e1 e2 q d.
 simple induction w.
 intro.
-cut (dans e1 q /\ e1 = e2 :>Elt); auto with v62.
+cut (dans e1 q /\ e1 = e2 :>Elt); auto.
 intro H0; elim H0; clear H0. 
-intros; apply chemin_nil; auto with v62.
+intros; apply chemin_nil; auto.
 intros x w0 H H0.
 cut
  (exists e : Elt,
     chemin e e2 q d w0 /\
     dans e1 q /\ dans x alph /\ dans (couple e1 (couple x e)) d);
- auto with v62.
+ auto.
 intro H1; elim H1.
 intros e H2; elim H2; clear H1 H2.
 intros H1 H2; elim H2; clear H2.
 intros H2 H3; elim H3; clear H3.
 intros.
-apply chemin_cons with e; auto with v62.
+apply chemin_cons with e; auto.
 Qed.
-Hint Resolve Chemin_chemin: v62.
+Hint Resolve Chemin_chemin.
 
 
 Lemma chemin_Chemin :
@@ -145,13 +145,13 @@ Lemma chemin_Chemin :
  chemin e1 e2 q d w -> Chemin e1 e2 q d w.
 intros e1 e2 q d w H; elim H; clear H.
 intros.
-red in |- *; simpl in |- *; auto with v62.
+red in |- *; simpl in |- *; auto.
 intros.
 red in |- *; simpl in |- *.
 exists e0.
-auto with v62.
+auto.
 Qed.
-Hint Resolve chemin_Chemin: v62.
+Hint Resolve chemin_Chemin.
 
 
 (*  									*)
@@ -178,21 +178,21 @@ Lemma dans_e1_q :
 intros q d.
 simple induction w.
 intros.
-cut (Chemin e1 e2 q d nil); auto with v62.
+cut (Chemin e1 e2 q d nil); auto.
 intro.
-cut (dans e1 q /\ e1 = e2 :>Elt); auto with v62.
-intro Ht; elim Ht; auto with v62.
+cut (dans e1 q /\ e1 = e2 :>Elt); auto.
+intro Ht; elim Ht; auto.
 intros x w0 H e1 e2 H0.
-cut (Chemin e1 e2 q d (cons x w0)); auto with v62.
+cut (Chemin e1 e2 q d (cons x w0)); auto.
 intro.
 cut
  (exists e : Elt,
     chemin e e2 q d w0 /\
     dans e1 q /\ dans x alph /\ dans (couple e1 (couple x e)) d);
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 intros e Ht; elim Ht; clear Ht.
-intros H2 Ht; elim Ht; auto with v62.
+intros H2 Ht; elim Ht; auto.
 Qed.
 
 Lemma dans_e2_q :
@@ -201,24 +201,24 @@ Lemma dans_e2_q :
 intros q d.
 simple induction w.
 intros.
-cut (Chemin e1 e2 q d nil); auto with v62.
+cut (Chemin e1 e2 q d nil); auto.
 intro.
-cut (dans e1 q /\ e1 = e2 :>Elt); auto with v62.
-intro Ht; elim Ht; auto with v62.
+cut (dans e1 q /\ e1 = e2 :>Elt); auto.
+intro Ht; elim Ht; auto.
 intros.
-rewrite <- H2; auto with v62.
+rewrite <- H2; auto.
 intros x w0 H e1 e2 H0.
-cut (Chemin e1 e2 q d (cons x w0)); auto with v62.
+cut (Chemin e1 e2 q d (cons x w0)); auto.
 intro.
 cut
  (exists e : Elt,
     chemin e e2 q d w0 /\
     dans e1 q /\ dans x alph /\ dans (couple e1 (couple x e)) d);
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 intros e Ht; elim Ht; clear Ht.
 intros H2 Ht.  
-apply (H e e2); auto with v62.
+apply (H e e2); auto.
 Qed.
 
 (*									*)
@@ -230,21 +230,21 @@ Lemma Cheminmonoid :
  automate q qd qa d ->
  forall e1 e2 : Elt, chemin e1 e2 q d w -> inmonoid alph w.
 simple induction w.
-auto with v62.
+auto.
 intros x w0 H q qd qa d H0 e1 e2 H1.
-cut (Chemin e1 e2 q d (cons x w0)); auto with v62.
+cut (Chemin e1 e2 q d (cons x w0)); auto.
 intro.
 cut
  (exists e : Elt,
     chemin e e2 q d w0 /\
     dans e1 q /\ dans x alph /\ dans (couple e1 (couple x e)) d);
- auto with v62.
+ auto.
 intro H3; elim H3; clear H3.
 intros e H3; elim H3; clear H3.
 intros H3 H4; elim H4; clear H4.
 intros H4 H5; elim H5; clear H5; intros.
-apply inmonoid_cons; auto with v62.
-apply (H q qd qa d H0 e e2); auto with v62.
+apply inmonoid_cons; auto.
+apply (H q qd qa d H0 e e2); auto.
 Qed.
 
 (*									*)
@@ -259,7 +259,7 @@ Lemma chemin_lettre :
  dans e2 q ->
  dans (couple e1 (couple x e2)) d -> chemin e1 e2 q d (cons x nil).
 intros.
-apply chemin_cons with e2; auto with v62. 
+apply chemin_cons with e2; auto. 
 Qed.
 
 (*									*)
@@ -274,7 +274,7 @@ Lemma automate_A_def2 :
  forall q qd qa d : Ensf, automate_A q qd qa d -> inclus qd q.
 intros.
 elim H.
-intros H0 Ht; elim Ht; auto with v62.
+intros H0 Ht; elim Ht; auto.
 Qed.
 
 (*									*)
@@ -297,7 +297,7 @@ Inductive chemin_A (q d : Ensf) : Elt -> Elt -> Word -> Prop :=
       chemin_A q d e e2 w ->
       dans e1 q ->
       dans (couple e1 (couple epsilon e)) d -> chemin_A q d e1 e2 w.
-Hint Resolve chemin_A_nil: v62.
+Hint Resolve chemin_A_nil.
 
 (*  Inversion de la definition...					*)
 
@@ -329,13 +329,13 @@ Lemma chemin_A_d1_d2 :
  chemin_A q d1 e1 e2 w -> inclus d1 d2 -> chemin_A q d2 e1 e2 w.
 intros q d d2 w e1 e2 H.
 elim H; clear H.
-auto with v62.
+auto.
 
 intros.
-apply chemin_A_cons with e; auto with v62.
+apply chemin_A_cons with e; auto.
 
 intros.
-apply chemin_A_epsilon with e; auto with v62.
+apply chemin_A_epsilon with e; auto.
 Qed.
 
 (*  De meme pour deux ensembles d'etats q1 et q2 tesl que q1 est inclus	*)
@@ -347,13 +347,13 @@ Lemma chemin_A_q1_q2 :
 intros q1 q2 d w e1 e2 H.
 elim H; clear H.
 
-auto with v62.
+auto.
 
 intros.
-apply chemin_A_cons with e; auto with v62.
+apply chemin_A_cons with e; auto.
 
 intros.
-apply chemin_A_epsilon with e; auto with v62.
+apply chemin_A_epsilon with e; auto.
 Qed.
 
 
@@ -365,10 +365,10 @@ Lemma chemin_chemin_A :
  chemin e1 e2 q d w -> chemin_A q d e1 e2 w.
 intros q d w e1 e2 H. 
 elim H; clear H.
-auto with v62.
+auto.
 
 intros.
-apply chemin_A_cons with e0; auto with v62.
+apply chemin_A_cons with e0; auto.
 Qed.
 
 (*									*)
@@ -384,18 +384,18 @@ intros e1 e e2 q d w1 w2 H.
 elim H.
 
 intros e0 e3 H0 H1 H2.
-simpl in |- *; rewrite H1; auto with v62.
+simpl in |- *; rewrite H1; auto.
 
 intros.
 simpl in |- *.
-cut (chemin_A q d e3 e2 (Append w w2)); auto with v62.
+cut (chemin_A q d e3 e2 (Append w w2)); auto.
 intro.
-apply chemin_A_cons with e3; auto with v62.
+apply chemin_A_cons with e3; auto.
 
 intros.
-cut (chemin_A q d e3 e2 (Append w w2)); auto with v62.
+cut (chemin_A q d e3 e2 (Append w w2)); auto.
 intro.
-apply chemin_A_epsilon with e3; auto with v62.
+apply chemin_A_epsilon with e3; auto.
 Qed.
 
 (*									*)
@@ -406,14 +406,14 @@ Lemma dansA_e1_q :
  forall (q d : Ensf) (w : Word) (e1 e2 : Elt),
  chemin_A q d e1 e2 w -> dans e1 q.
 intros.
-elim H; auto with v62.
+elim H; auto.
 Qed.
 
 Lemma dansA_e2_q :
  forall (q d : Ensf) (w : Word) (e1 e2 : Elt),
  chemin_A q d e1 e2 w -> dans e2 q.
 intros.
-elim H; auto with v62.
+elim H; auto.
 intros e0 e3 H0 H1.
 rewrite <- H1.
 assumption.
@@ -429,7 +429,7 @@ Lemma cheminA_monoid :
  automate_A q qd qaA dA ->
  forall e1 e2 : Elt, chemin_A q dA e1 e2 w -> inmonoid alph w.
 intros.
-elim H0; auto with v62.
+elim H0; auto.
 Qed.
 
 
@@ -444,11 +444,11 @@ Lemma chemin_A2_cons_inv : (q,dA:Ensf)(w:Word)(e1,e2,x:Elt)
 Intros.
 Elim H.
 Intros.
-Cut (Chemin e0 e2 q dA (cons x w)); Auto with v62.
+Cut (Chemin e0 e2 q dA (cons x w)); Auto.
 Intro.
 Cut (<Elt> Ex ([e:Elt]
       	  (chemin e e2 q dA w) /\ (dans e0 q) /\ (dans x alph)
-   	  /\ (dans (couple e0 (couple x e)) dA)) ); Auto with v62.
+   	  /\ (dans (couple e0 (couple x e)) dA)) ); Auto.
 Intro Ht; Elim Ht; Clear Ht.
 Intros e Ht; Elim Ht; Clear Ht.
 Intros H3 Ht; Elim Ht; Clear Ht.
@@ -456,20 +456,20 @@ Intros H4 Ht; Elim Ht; Clear Ht.
 Intros H5 H6.
 Exists e.
 Split.
-2:Apply chemin_A2_un; Auto with v62.
-2:Apply (inmonoid_cons_inv alph w x); Auto with v62.
-Cut (chemin e0 e q dA (cons x nil)); Auto with v62.
-Apply (chemin_cons e e q dA nil e0 x); Auto with v62.
-Apply chemin_nil; Auto with v62.
-Apply (dans_e1_q q dA w e e2); Auto with v62.
+2:Apply chemin_A2_un; Auto.
+2:Apply (inmonoid_cons_inv alph w x); Auto.
+Cut (chemin e0 e q dA (cons x nil)); Auto.
+Apply (chemin_cons e e q dA nil e0 x); Auto.
+Apply chemin_nil; Auto.
+Apply (dans_e1_q q dA w e e2); Auto.
 
 Intros.
 Elim H1.
 Intros e0' Ht; Elim Ht; Clear Ht. 
 Intros H4 H5.
 Exists e0'.
-Split; Auto with v62.
-Apply chemin_A2_deux with e; Auto with v62.
+Split; Auto.
+Apply chemin_A2_deux with e; Auto.
 Save.
 
 Lemma chemin_A_cons_inv : (q,dA:Ensf)(w:Word)(e1,e2,x:Elt)
@@ -480,12 +480,12 @@ Goal.
 Cut (<Elt>Ex ([e:Elt](
      (chemin_A2 q dA (cons x nil) e e1) /\ (chemin_A2 q dA w e2 e)
   ))).
-2:Apply chemin_A2_cons_inv; Auto with v62.
+2:Apply chemin_A2_cons_inv; Auto.
 Intro Ht; Elim Ht; Clear Ht.
 Intros e Ht; Elim Ht; Clear Ht.
 Intros H0 H1.
 Exists e.
-Auto with v62.
+Auto.
 Save.
 ---*)
 
@@ -535,14 +535,14 @@ Definition sync_qa (q qaA dA : Ensf) : Ensf :=
     (tq
        (fun e : Elt => exists e' : Elt, dans e' qaA /\ chemin_A q dA e e' nil)
        q).
-Hint Unfold sync_qa: v62.
+Hint Unfold sync_qa.
 
 (*  Les etats de d'arrivee de l'automate fini comprennent ceux de	*)
 (*  l'automate asynchrone.						*)
 
 Lemma inclus_qaA_qa : forall q qaA dA : Ensf, inclus qaA (sync_qa q qaA dA).
 unfold sync_qa in |- *.
-auto with v62.
+auto.
 Qed.
 
 (*  Par definition on a...						*)
@@ -558,8 +558,8 @@ intros e' Ht; elim Ht; clear Ht.
 intros H0 H1.
 unfold sync_qa in |- *.
 apply union_d.
-apply imp_dans_tq; auto with v62.
-exists e'; auto with v62.
+apply imp_dans_tq; auto.
+exists e'; auto.
 Qed.
 
 (*  et aussi...								*)
@@ -571,11 +571,11 @@ Lemma sync_d_def :
  dans (couple e1 (couple x e2)) (sync_d q dA).
 intros.
 unfold sync_d in |- *.
-apply imp_dans_tq; auto with v62.
+apply imp_dans_tq; auto.
 apply coupl2_inv.
-apply (dansA_e1_q q dA (cons x nil) e1 e2); auto with v62.
-apply coupl2_inv; auto with v62.
-apply (dansA_e2_q q dA (cons x nil) e1 e2); auto with v62.
+apply (dansA_e1_q q dA (cons x nil) e1 e2); auto.
+apply coupl2_inv; auto.
+apply (dansA_e2_q q dA (cons x nil) e1 e2); auto.
 Qed.
 
 Lemma sync_d_def2 :
@@ -589,12 +589,12 @@ intro.
 cut
  (dans (couple e1 (couple x e2)) (prodcart q (prodcart alph q)) /\
   est_dans_d q dA (couple e1 (couple x e2))).
-2: apply dans_tq_imp; auto with v62.
+2: apply dans_tq_imp; auto.
 intro Ht; elim Ht; clear Ht.
 intro H1.
 unfold est_dans_d in |- *.
 unfold est_dans_d2 in |- *.
-auto with v62.
+auto.
 Qed.
 
 Lemma trans_dA_d :
@@ -608,10 +608,10 @@ intros.
 cut (chemin_A q dA e0 e (cons x nil)).
 intro.
 unfold sync_d in |- *.
-apply imp_dans_tq; auto with v62.
-cut (chemin_A q dA e e nil); auto with v62.
+apply imp_dans_tq; auto.
+cut (chemin_A q dA e e nil); auto.
 intro.
-apply chemin_A_cons with e; auto with v62.
+apply chemin_A_cons with e; auto.
 Qed.
 
 (* 									*)
@@ -629,9 +629,9 @@ intros H1 H2; elim H2; clear H2; intros H2 H3.
 red in |- *.
 split.
 unfold sync_qa in |- *.
-apply union_inclus; auto with v62.
+apply union_inclus; auto.
 apply inclus_tq.
-split; auto with v62.
+split; auto.
 unfold sync_d in |- *.
 apply inclus_tq.
 Qed.
@@ -657,15 +657,15 @@ simple induction w.
 intros.
 exists e1.
 split.
-auto with v62.
-cut (Chemin e e2 q (sync_d q dA) nil); auto with v62.
+auto.
+cut (Chemin e e2 q (sync_d q dA) nil); auto.
 intro H3.
-cut (dans e q /\ e = e2 :>Elt); auto with v62.
+cut (dans e q /\ e = e2 :>Elt); auto.
 intro Ht; elim Ht; clear Ht.
 intros H4 H5.
-cut (chemin_A q dA e e2 nil); auto with v62.
+cut (chemin_A q dA e e2 nil); auto.
 cut (chemin_A q dA e1 e2 nil).
-2: apply chemin_A_epsilon with e; auto with v62.
+2: apply chemin_A_epsilon with e; auto.
 intros.
 unfold sync_qa in H1.
 cut
@@ -674,10 +674,10 @@ cut
     (tq
        (fun e : Elt => exists e' : Elt, dans e' qaA /\ chemin_A q dA e e' nil)
        q)).   
-2: apply dans_union; auto with v62.
+2: apply dans_union; auto.
 intro Ht; elim Ht; clear Ht.
-intro; apply nouvx_dans_qa; auto with v62.
-exists e2; auto with v62.
+intro; apply nouvx_dans_qa; auto.
+exists e2; auto.
 
 intro.
 cut
@@ -693,38 +693,38 @@ intro Ht; elim Ht; clear Ht.
 intros H9 Ht; elim Ht; clear Ht.
 intros e3 Ht; elim Ht; clear Ht.
 intros H10 H11.
-cut (chemin_A q dA e e3 nil); auto with v62.
-2: rewrite H5; auto with v62.
+cut (chemin_A q dA e e3 nil); auto.
+2: rewrite H5; auto.
 intro H12.
 cut (chemin_A q dA e1 e3 nil).
-2: apply chemin_A_epsilon with e; auto with v62.
-intro; apply nouvx_dans_qa; auto with v62.
-exists e3; auto with v62.
+2: apply chemin_A_epsilon with e; auto.
+intro; apply nouvx_dans_qa; auto.
+exists e3; auto.
 
 intros x w0 H e1 e e2 H0 H1 H2 H3.
-cut (Chemin e e2 q (sync_d q dA) (cons x w0)); auto with v62.
+cut (Chemin e e2 q (sync_d q dA) (cons x w0)); auto.
 intro.
 cut
  (exists e22 : Elt,
     chemin e22 e2 q (sync_d q dA) w0 /\
     dans e q /\ dans x alph /\ dans (couple e (couple x e22)) (sync_d q dA));
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 intros e22 Ht; elim Ht; clear Ht.
 intros H5 Ht; elim Ht; clear Ht.
 intros H6 Ht; elim Ht; clear Ht; intros H7 H8.
 exists e2.
-split; auto with v62.
+split; auto.
 cut (chemin_A q dA e e22 (cons x nil)).
-2: apply sync_d_def2; auto with v62.
+2: apply sync_d_def2; auto.
 intro.
 cut (chemin_A q dA e1 e22 (cons x nil)).
-2: apply chemin_A_epsilon with e; auto with v62.
+2: apply chemin_A_epsilon with e; auto.
 intro.
 cut (dans (couple e1 (couple x e22)) (sync_d q dA)).
-2: apply sync_d_def; auto with v62.
+2: apply sync_d_def; auto.
 intro.
-apply chemin_cons with e22; auto with v62.
+apply chemin_cons with e22; auto.
 Qed.
 
 (*									*)
@@ -752,35 +752,35 @@ elim H1.
 intros e0 e3 H H2 H3.
 exists e0.
 split.
-apply chemin_nil; auto with v62.
+apply chemin_nil; auto.
 rewrite H2.
-apply dans_trans with qaA; auto with v62.
+apply dans_trans with qaA; auto.
 
 intros.
 cut
  (exists e2' : Elt,
     chemin e e2' q (sync_d q dA) w0 /\ dans e2' (sync_qa q qaA dA));
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 intros e2' Ht; elim Ht; clear Ht.
 intros H7 H8.
 exists e2'.
-split; auto with v62.
-apply chemin_cons with e; auto with v62.
+split; auto.
+apply chemin_cons with e; auto.
 cut (dans e q).
-2: apply (dans_e1_q q (sync_d q dA) w0 e e2'); auto with v62.
+2: apply (dans_e1_q q (sync_d q dA) w0 e e2'); auto.
 intro dans_e_q.
-apply trans_dA_d; auto with v62.
+apply trans_dA_d; auto.
 
 intros.
 cut
  (exists e2' : Elt,
     chemin e e2' q (sync_d q dA) w0 /\ dans e2' (sync_qa q qaA dA));
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 intros e9 Ht; elim Ht; clear Ht.
 intros H6 H7.
-apply (epsilon_chemin q qaA dA w0 e0 e e9); auto with v62.
+apply (epsilon_chemin q qaA dA w0 e0 e e9); auto.
 Qed.
 
 (*									*)
@@ -802,17 +802,17 @@ intros e1 H; elim H; clear H.
 intros e2 H; elim H; clear H.
 intros H2 H; elim H; clear H; intros H3 H4.
 unfold reconnait in |- *.
-split; auto with v62. 
+split; auto. 
 exists e1.
 cut
  (exists e2' : Elt,
     chemin e1 e2' q (sync_d q dA) w /\ dans e2' (sync_qa q qaA dA)). 
-2: apply (cheminA_chemin q qd qaA dA H_aut w e1 e2); auto with v62.
+2: apply (cheminA_chemin q qd qaA dA H_aut w e1 e2); auto.
 intro Ht; elim Ht; clear Ht.
 intros e2' Ht; elim Ht; clear Ht.
 intros H5 H6.
 exists e2'.
-auto with v62.
+auto.
 Qed.
 
 (*									*)
@@ -829,33 +829,33 @@ Lemma chemin_cheminA :
 intros q qd qaA dA H_aut.
 simple induction w.
 intros.
-cut (Chemin e1 e2 q (sync_d q dA) nil); auto with v62.
+cut (Chemin e1 e2 q (sync_d q dA) nil); auto.
 
 intro.
-cut (dans e1 q /\ e1 = e2 :>Elt); auto with v62.
+cut (dans e1 q /\ e1 = e2 :>Elt); auto.
 intro Ht; elim Ht; clear Ht.
-intros; apply chemin_A_nil; auto with v62.
+intros; apply chemin_A_nil; auto.
 
 intros x w0 H e1 e2 H0.
-cut (Chemin e1 e2 q (sync_d q dA) (cons x w0)); auto with v62.
+cut (Chemin e1 e2 q (sync_d q dA) (cons x w0)); auto.
 intro H1.
 cut
  (exists e : Elt,
     chemin e e2 q (sync_d q dA) w0 /\
     dans e1 q /\ dans x alph /\ dans (couple e1 (couple x e)) (sync_d q dA));
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 intros e Ht; elim Ht; clear Ht.
 intros H2 Ht; elim Ht; clear Ht.
 intros H3 H4.
-cut (chemin_A q dA e e2 w0); auto with v62.
+cut (chemin_A q dA e e2 w0); auto.
 intro.
 elim H4; clear H4; intros H4 H6.
 cut (chemin_A q dA e1 e (cons x nil)).
-2: apply sync_d_def2; auto with v62.
+2: apply sync_d_def2; auto.
 intro.
-replace (cons x w0) with (Append (cons x nil) w0); auto with v62.
-apply chemin_Append with e; auto with v62.
+replace (cons x w0) with (Append (cons x nil) w0); auto.
+apply chemin_Append with e; auto.
 Qed.
 
 (*									*)
@@ -882,7 +882,7 @@ cut
        (tq
           (fun e : Elt =>
            exists e' : Elt, dans e' qaA /\ chemin_A q dA e e' nil) q)));
- auto with v62.
+ auto.
 intro H3.
 cut
  (dans e2 qaA \/
@@ -890,18 +890,18 @@ cut
     (tq
        (fun e : Elt => exists e' : Elt, dans e' qaA /\ chemin_A q dA e e' nil)
        q)).
-2: apply dans_union; auto with v62.
+2: apply dans_union; auto.
 intro H4.
 unfold reconnait_A in |- *.
-split; auto with v62.
+split; auto.
 exists e1.
 clear H3; elim H4.
 
 intro.
 exists e2.
-split; auto with v62.
-split; auto with v62.
-apply (chemin_cheminA q qd qaA dA H_aut); auto with v62.
+split; auto.
+split; auto.
+apply (chemin_cheminA q qd qaA dA H_aut); auto.
 
 intro.
 cut
@@ -912,19 +912,19 @@ cut
      with
        (f := fun e : Elt =>
              exists e' : Elt, dans e' qaA /\ chemin_A q dA e e' nil);
-    auto with v62.
+    auto.
 intro Ht; elim Ht; clear Ht.
 intros H5 Ht; elim Ht; clear Ht. 
 intros e2' Ht; elim Ht; clear Ht.
 intros H6 H7.
 exists e2'.
-split; auto with v62.
-split; auto with v62.
+split; auto.
+split; auto.
 cut (chemin_A q dA e1 e2 w). 
-2: apply (chemin_cheminA q qd qaA dA H_aut); auto with v62.
+2: apply (chemin_cheminA q qd qaA dA H_aut); auto.
 intro.
 replace w with (Append w nil).
-apply chemin_Append with e2; auto with v62.
+apply chemin_Append with e2; auto.
 apply Append_w_nil.
 Qed.
 
@@ -948,13 +948,13 @@ intros q qd qaA dA H.
 exists (sync_d q dA).
 exists (sync_qa q qaA dA).
 split.
-apply automateA_automate; auto with v62.
+apply automateA_automate; auto.
 unfold eqwordset in |- *.
 split.
 intro.
-apply reconnaitA_reconnait; auto with v62.
+apply reconnaitA_reconnait; auto.
 intro.
-apply reconnait_reconnaitA; auto with v62.
+apply reconnait_reconnaitA; auto.
 Qed.
 
 
@@ -1009,7 +1009,7 @@ cut
     (exists qa : Ensf,
        automate q qd qa d /\
        eqwordset (reconnait_A q qd qaA dA) (reconnait q qd qa d))).
-2: apply async_is_sync; auto with v62.
+2: apply async_is_sync; auto.
 intro Ht; elim Ht; clear Ht.
 intros d Ht; elim Ht; clear Ht.
 intros qa Ht; elim Ht; clear Ht.
@@ -1019,9 +1019,9 @@ exists q.
 exists qd.
 exists qa.
 exists d.
-split; auto with v62.
-apply eqwordset_trans with (reconnait_A q qd qaA dA); auto with v62.
-apply eqwordset_sym; auto with v62.
+split; auto.
+apply eqwordset_trans with (reconnait_A q qd qaA dA); auto.
+apply eqwordset_sym; auto.
 Qed.
 
 Definition isregular_D (l : wordset) : Prop :=
@@ -1045,25 +1045,25 @@ Lemma automate_A_D :
 unfold automate_A in |- *.
 split.
 apply inclus_add.
-apply automate_def3 with qd d; auto with v62.
-split; auto with v62.
+apply automate_def3 with qd d; auto.
+split; auto.
 apply union_inclus.
 apply inclus_trans with (prodcart q (prodcart alph q)).
 apply automate_def1 with qd qa; assumption.
-apply cart_inclus; auto with v62.
+apply cart_inclus; auto.
 unfold delta_D in |- *.
 unfold inclus in |- *.
 intros x H2.
 cut (exists y : Elt, dans y qd /\ x = transition_D g0 y :>Elt).
-2: apply dans_map; auto with v62.
+2: apply dans_map; auto.
 intro Ht; elim Ht; clear Ht; intros t Ht; elim Ht; clear Ht; intros.
 rewrite H1.
 unfold transition_D in |- *.
-apply coupl2_inv; auto with v62.
-apply coupl2_inv; auto with v62.
+apply coupl2_inv; auto.
+apply coupl2_inv; auto.
 apply dans_add2.
-apply dans_trans with qd; auto with v62.
-apply automate_def2 with qa d; auto with v62.
+apply dans_trans with qd; auto.
+apply automate_def2 with qa d; auto.
 Qed.
 
 (*									*)
@@ -1080,42 +1080,42 @@ Lemma chemin_D_chemin :
 intros q qd qa d g0 e e2 w H_aut H_g0 H.
 elim H; clear H.
 
-auto with v62.
+auto.
 
 intros e1 e0 e3 x w0 H H0 H1 H2 H3 H4.
 cut
  (dans (couple e1 (couple x e0)) d \/
   dans (couple e1 (couple x e0)) (delta_D g0 qd)); 
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 	intro.
 	cut (dans (couple e1 (couple x e0)) (prodcart q (prodcart alph q))).
-	2: apply dans_trans with d; auto with v62.
-	2: apply automate_def1 with qd qa; auto with v62.
+	2: apply dans_trans with d; auto.
+	2: apply automate_def1 with qd qa; auto.
 	intro.
 	cut (dans e1 q /\ dans (couple x e0) (prodcart alph q)).
-	2: apply coupl2; auto with v62.	
+	2: apply coupl2; auto.	
 	intro Ht; elim Ht; clear Ht; intros.
 	cut (dans x alph /\ dans e0 q).
-	2: apply coupl2; auto with v62.	
+	2: apply coupl2; auto.	
 	intro Ht; elim Ht; clear Ht; intros.
-	apply chemin_cons with e0; auto with v62.
+	apply chemin_cons with e0; auto.
 
 	unfold delta_D in |- *.
 	intro H5.
 	cut
   (exists y : Elt,
      dans y qd /\ couple e1 (couple x e0) = transition_D g0 y :>Elt).
-	2: apply dans_map; auto with v62.
+	2: apply dans_map; auto.
 	intro Ht; elim Ht; clear Ht; intros y' Ht; elim Ht; clear Ht; intros.
 	unfold transition_D in H7.
 	cut (e1 = g0 :>Elt /\ couple x e0 = couple epsilon y' :>Elt).
-	2: apply equal_couple; auto with v62.
+	2: apply equal_couple; auto.
 	intro Ht; elim Ht; clear Ht; intros.
 	cut (x = epsilon :>Elt /\ e0 = y' :>Elt).
-	2: apply equal_couple; auto with v62.
+	2: apply equal_couple; auto.
 	intro Ht; elim Ht; clear Ht; intros.
-	absurd (dans x alph); auto with v62.
+	absurd (dans x alph); auto.
 	rewrite H10.
 	red in |- *; intro; apply not_dans_epsilon_alph; assumption.
 
@@ -1123,20 +1123,20 @@ intros e1 e0 e3 w0 H H1 H2 H3 H4.
 cut
  (dans (couple e1 (couple epsilon e0)) d \/
   dans (couple e1 (couple epsilon e0)) (delta_D g0 qd)); 
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 	intro.
 	cut (dans (couple e1 (couple epsilon e0)) (prodcart q (prodcart alph q))).
-	2: apply dans_trans with d; auto with v62.
-	2: apply automate_def1 with qd qa; auto with v62.
+	2: apply dans_trans with d; auto.
+	2: apply automate_def1 with qd qa; auto.
 	intro.
 	cut (dans e1 q /\ dans (couple epsilon e0) (prodcart alph q)).
-	2: apply coupl2; auto with v62.	
+	2: apply coupl2; auto.	
 	intro Ht; elim Ht; clear Ht; intros.
 	cut (dans epsilon alph /\ dans e0 q).
-	2: apply coupl2; auto with v62.	
+	2: apply coupl2; auto.	
 	intro Ht; elim Ht; clear Ht; intros.
-	absurd (dans epsilon alph); auto with v62.
+	absurd (dans epsilon alph); auto.
 	red in |- *; intro; apply not_dans_epsilon_alph; assumption.
 
 	unfold delta_D in |- *.
@@ -1144,13 +1144,13 @@ intro Ht; elim Ht; clear Ht.
 	cut
   (exists y : Elt,
      dans y qd /\ couple e1 (couple epsilon e0) = transition_D g0 y :>Elt).
-	2: apply dans_map; auto with v62.
+	2: apply dans_map; auto.
 	intro Ht; elim Ht; clear Ht; intros y' Ht; elim Ht; clear Ht; intros.
 	unfold transition_D in H6.
 	cut (e1 = g0 :>Elt /\ couple epsilon e0 = couple epsilon y' :>Elt).
-	2: apply equal_couple; auto with v62.
+	2: apply equal_couple; auto.
 	intro Ht; elim Ht; clear Ht; intros.
-	absurd (dans g0 q); auto with v62.
+	absurd (dans g0 q); auto.
 	rewrite <- H7.
 	assumption. 
 Qed.
@@ -1174,27 +1174,27 @@ intros q qd qa d g0 e1 e2 w H_aut H_g0 H.
 elim H; clear H.
 
 intros e0 e3 H H0 H1 H2.
-absurd (dans g0 q); auto with v62.
+absurd (dans g0 q); auto.
 rewrite <- H1.
 rewrite H0.
-apply dans_trans with qa; auto with v62.
-apply automate_def3 with qd d; auto with v62.
+apply dans_trans with qa; auto.
+apply automate_def3 with qd d; auto.
 
 intros e0 e e3 x w0 H H0 H1 H2 H3 H4 H5.
 clear H0.
 cut
  (dans (couple e0 (couple x e)) d \/
-  dans (couple e0 (couple x e)) (delta_D g0 qd)); auto with v62.
+  dans (couple e0 (couple x e)) (delta_D g0 qd)); auto.
 intro Ht; elim Ht; clear Ht.
 	intro.
 	cut (dans (couple e0 (couple x e)) (prodcart q (prodcart alph q))).
-	2: apply dans_trans with d; auto with v62.
-	2: apply automate_def1 with qd qa; auto with v62.
+	2: apply dans_trans with d; auto.
+	2: apply automate_def1 with qd qa; auto.
 	intro.
 	cut (dans e0 q /\ dans (couple x e) (prodcart alph q)).
-	2: apply coupl2; auto with v62.	
+	2: apply coupl2; auto.	
 	intro Ht; elim Ht; clear Ht; intros.
-	absurd (dans g0 q); auto with v62.
+	absurd (dans g0 q); auto.
 	rewrite <- H4.
 	assumption.
 	
@@ -1203,16 +1203,16 @@ intro Ht; elim Ht; clear Ht.
 	cut
   (exists y : Elt,
      dans y qd /\ couple e0 (couple x e) = transition_D g0 y :>Elt).
-	2: apply dans_map; auto with v62.
+	2: apply dans_map; auto.
 	intro Ht; elim Ht; clear Ht; intros y' Ht; elim Ht; clear Ht; intros.
 	unfold transition_D in H7.
 	cut (e0 = g0 :>Elt /\ couple x e = couple epsilon y' :>Elt).
-	2: apply equal_couple; auto with v62.
+	2: apply equal_couple; auto.
 	intro Ht; elim Ht; clear Ht; intros.
 	cut (x = epsilon :>Elt /\ e = y' :>Elt).
-	2: apply equal_couple; auto with v62.
+	2: apply equal_couple; auto.
 	intro Ht; elim Ht; clear Ht; intros.
-	absurd (dans x alph); auto with v62.
+	absurd (dans x alph); auto.
 	rewrite H10.
 	red in |- *; intro; apply not_dans_epsilon_alph; assumption.
 
@@ -1224,20 +1224,20 @@ split.
 cut
  (dans (couple e0 (couple epsilon e)) d \/
   dans (couple e0 (couple epsilon e)) (delta_D g0 qd)); 
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 	intro.
 	cut (dans (couple e0 (couple epsilon e)) (prodcart q (prodcart alph q))).
-	2: apply dans_trans with d; auto with v62.
-	2: apply automate_def1 with qd qa; auto with v62.
+	2: apply dans_trans with d; auto.
+	2: apply automate_def1 with qd qa; auto.
 	intro.
 	cut (dans e0 q /\ dans (couple epsilon e) (prodcart alph q)).
-	2: apply coupl2; auto with v62.	
+	2: apply coupl2; auto.	
 	intro Ht; elim Ht; clear Ht; intros.
 	cut (dans epsilon alph /\ dans e q).
-	2: apply coupl2; auto with v62.	
+	2: apply coupl2; auto.	
 	intro Ht; elim Ht; clear Ht; intros.
-	absurd (dans epsilon alph); auto with v62.
+	absurd (dans epsilon alph); auto.
 	red in |- *; intro; apply not_dans_epsilon_alph; assumption.
 	
 	unfold delta_D in |- *.
@@ -1245,14 +1245,14 @@ intro Ht; elim Ht; clear Ht.
 	cut
   (exists y : Elt,
      dans y qd /\ couple e0 (couple epsilon e) = transition_D g0 y :>Elt).
-	2: apply dans_map; auto with v62.
+	2: apply dans_map; auto.
 	intro Ht; elim Ht; clear Ht; intros y' Ht; elim Ht; clear Ht; intros.
 	unfold transition_D in H6.
 	cut (e0 = g0 :>Elt /\ couple epsilon e = couple epsilon y' :>Elt).
-	2: apply equal_couple; auto with v62.
+	2: apply equal_couple; auto.
 	intro Ht; elim Ht; clear Ht; intros.
 	cut (epsilon = epsilon :>Elt /\ e = y' :>Elt).
-	2: apply equal_couple; auto with v62.
+	2: apply equal_couple; auto.
 	intro Ht; elim Ht; clear Ht; intros.
 	rewrite H10.
 	assumption.
@@ -1270,33 +1270,33 @@ Lemma chemin_A_e1_g0_abs :
  e2 = g0 :>Elt -> ~ chemin_A (add g0 q) (union d (delta_D g0 qd)) e e2 w.
 intros q qd qa d g0 e e2 w H_aut H H0 H1.
 red in |- *; intro.
-cut (dans e q); auto with v62.
-cut (e2 = g0 :>Elt); auto with v62.
+cut (dans e q); auto.
+cut (e2 = g0 :>Elt); auto.
 elim H2.
 
 intros e1 e0 H3 H4 H5 H6.
-absurd (dans g0 q); auto with v62.
+absurd (dans g0 q); auto.
 rewrite <- H5.
 rewrite <- H4; assumption.
 
 intros e1 e0 e3 x w0 H3 H4 H5 H6 H7 H8 H9.
-apply H4; auto with v62.
+apply H4; auto.
 cut
  (dans (couple e1 (couple x e0)) d \/
   dans (couple e1 (couple x e0)) (delta_D g0 qd)); 
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 
 	intro.
 	cut (dans (couple e1 (couple x e0)) (prodcart q (prodcart alph q))).
-	2: apply dans_trans with d; auto with v62.
-	2: apply automate_def1 with qd qa; auto with v62.
+	2: apply dans_trans with d; auto.
+	2: apply automate_def1 with qd qa; auto.
 	intro.	
 	cut (dans e1 q /\ dans (couple x e0) (prodcart alph q)).
-	2: apply coupl2; auto with v62.
+	2: apply coupl2; auto.
 	intro Ht; elim Ht; clear Ht; intros.
 	cut (dans x alph /\ dans e0 q).
-	2: apply coupl2; auto with v62.
+	2: apply coupl2; auto.
 	intro Ht; elim Ht; clear Ht; intros.
 	assumption.
 	
@@ -1305,49 +1305,49 @@ intro Ht; elim Ht; clear Ht.
 	cut
   (exists y : Elt,
      dans y qd /\ couple e1 (couple x e0) = transition_D g0 y :>Elt).
-	2: apply dans_map; auto with v62.
+	2: apply dans_map; auto.
 	intro Ht; elim Ht; clear Ht; intros y' Ht; elim Ht; clear Ht; intros.
 	unfold transition_D in H12.
 	cut (e1 = g0 :>Elt /\ couple x e0 = couple epsilon y' :>Elt).
-	2: apply equal_couple; auto with v62.
+	2: apply equal_couple; auto.
 	intro Ht; elim Ht; clear Ht; intros.
-	absurd (dans e1 q); auto with v62.
-	rewrite H13; auto with v62.
+	absurd (dans e1 q); auto.
+	rewrite H13; auto.
 
 intros e1 e0 e3 w0 H3 H4 H5 H6 H7 H8.
-apply H4; auto with v62.
+apply H4; auto.
 cut
  (dans (couple e1 (couple epsilon e0)) d \/
   dans (couple e1 (couple epsilon e0)) (delta_D g0 qd)); 
- auto with v62.
+ auto.
 intro Ht; elim Ht; clear Ht.
 
 	intro.
 	cut (dans (couple e1 (couple epsilon e0)) (prodcart q (prodcart alph q))).
-	2: apply dans_trans with d; auto with v62.
-	2: apply automate_def1 with qd qa; auto with v62.
+	2: apply dans_trans with d; auto.
+	2: apply automate_def1 with qd qa; auto.
 	intro.	
 	cut (dans e1 q /\ dans (couple epsilon e0) (prodcart alph q)).
-	2: apply coupl2; auto with v62.
+	2: apply coupl2; auto.
 	intro Ht; elim Ht; clear Ht; intros.
 	cut (dans epsilon alph /\ dans e0 q).
-	2: apply coupl2; auto with v62.
+	2: apply coupl2; auto.
 	intro Ht; elim Ht; clear Ht; intros.
-	absurd (dans epsilon alph); auto with v62.
+	absurd (dans epsilon alph); auto.
 	
 	unfold delta_D in |- *.
 	intro.
 	cut
   (exists y : Elt,
      dans y qd /\ couple e1 (couple epsilon e0) = transition_D g0 y :>Elt).
-	2: apply dans_map; auto with v62.
+	2: apply dans_map; auto.
 	intro Ht; elim Ht; clear Ht; intros y' Ht; elim Ht; clear Ht; intros.
 	unfold transition_D in H11.
 	cut (e1 = g0 :>Elt /\ couple epsilon e0 = couple epsilon y' :>Elt).
-	2: apply equal_couple; auto with v62.
+	2: apply equal_couple; auto.
 	intro Ht; elim Ht; clear Ht; intros.
-	absurd (dans e1 q); auto with v62.
-	rewrite H12; auto with v62.
+	absurd (dans e1 q); auto.
+	rewrite H12; auto.
 Qed.
 
 
@@ -1363,27 +1363,27 @@ Lemma chemin_A_e1_g0 :
  chemin_A (add g0 q) (union d (delta_D g0 qd)) e1 e2 w ->
  e2 = g0 :>Elt -> w = nil :>Word.
 intros q qd qa d g0 e1 e2 w H_aut H_g0 H.
-elim H; auto with v62.
+elim H; auto.
 intros e0 e e3 x w0 H0 H1 H2 H3 H4 H5.
 absurd (chemin_A (add g0 q) (union d (delta_D g0 qd)) e g0 w0).
-2: cut (chemin_A (add g0 q) (union d (delta_D g0 qd)) e e3 w0); auto with v62.
-2: rewrite H5; auto with v62.
-apply chemin_A_e1_g0_abs with qa; auto with v62.
+2: cut (chemin_A (add g0 q) (union d (delta_D g0 qd)) e e3 w0); auto.
+2: rewrite H5; auto.
+apply chemin_A_e1_g0_abs with qa; auto.
 cut
  (dans (couple e0 (couple x e)) d \/
-  dans (couple e0 (couple x e)) (delta_D g0 qd)); auto with v62.
+  dans (couple e0 (couple x e)) (delta_D g0 qd)); auto.
 intro Ht; elim Ht; clear Ht.
 
 intro.
 cut (dans (couple e0 (couple x e)) (prodcart q (prodcart alph q))).
-2: apply dans_trans with d; auto with v62.
-2: apply automate_def1 with qd qa; auto with v62.
+2: apply dans_trans with d; auto.
+2: apply automate_def1 with qd qa; auto.
 intro.
 cut (dans e0 q /\ dans (couple x e) (prodcart alph q)).
-2: apply coupl2; auto with v62.
+2: apply coupl2; auto.
 intro Ht; elim Ht; clear Ht; intros.
 cut (dans x alph /\ dans e q).
-2: apply coupl2; auto with v62.
+2: apply coupl2; auto.
 intro Ht; elim Ht; clear Ht; intros.
 assumption.
 
@@ -1392,16 +1392,16 @@ intro.
 cut
  (exists y : Elt,
     dans y qd /\ couple e0 (couple x e) = transition_D g0 y :>Elt).
-2: apply dans_map; auto with v62.
+2: apply dans_map; auto.
 intro Ht; elim Ht; clear Ht; intros y' Ht; elim Ht; clear Ht; intros.
 unfold transition_D in H8.
 cut (e0 = g0 :>Elt /\ couple x e = couple epsilon y' :>Elt).
-2: apply equal_couple; auto with v62.
+2: apply equal_couple; auto.
 intro Ht; elim Ht; clear Ht; intros.
 cut (x = epsilon :>Elt /\ e = y' :>Elt).
-2: apply equal_couple; auto with v62.
+2: apply equal_couple; auto.
 intro Ht; elim Ht; clear Ht; intros.
-absurd (dans x alph); auto with v62.
+absurd (dans x alph); auto.
 rewrite H11.
 red in |- *; intro; apply not_dans_epsilon_alph; assumption.
 Qed.
@@ -1435,16 +1435,16 @@ split.
 	assumption.
 	exists g0.
 	exists e2.
-	split; [ auto with v62 | split ].
+	split; [ auto | split ].
 	assumption.
-	apply chemin_A_epsilon with e1; auto with v62.
-	apply chemin_A_d1_d2 with d; auto with v62.
-	apply chemin_A_q1_q2 with q; auto with v62.
-	apply chemin_chemin_A; auto with v62.
+	apply chemin_A_epsilon with e1; auto.
+	apply chemin_A_d1_d2 with d; auto.
+	apply chemin_A_q1_q2 with q; auto.
+	apply chemin_chemin_A; auto.
 	apply union_d.
 	unfold delta_D in |- *.
 	replace (couple g0 (couple epsilon e1)) with (transition_D g0 e1);
-  auto with v62.
+  auto.
 
 	unfold reconnait_A in |- *.
 	intro Ht; elim Ht; clear Ht; intros H1 Ht; elim Ht; clear Ht; intros e1 Ht;
@@ -1453,23 +1453,23 @@ split.
 	unfold reconnait in |- *.
 	split.
 	assumption.
-	cut (e1 = g0 :>Elt); auto with v62.
+	cut (e1 = g0 :>Elt); auto.
 	intro.
 	cut
   (exists e : Elt,
      dans e qd /\ chemin_A (add g0 q) (union d (delta_D g0 qd)) e e2 w).
-	2: apply chemin_A_g0_e2 with qa e1; auto with v62.
+	2: apply chemin_A_g0_e2 with qa e1; auto.
 	intro Ht; elim Ht; clear Ht; intros e Ht; elim Ht; clear Ht; intros.
 	exists e.
 	exists e2.
 	split; [ assumption | split ].
 	assumption.
-	apply chemin_D_chemin with qd qa g0; auto with v62.
-	apply dans_trans with qd; auto with v62.
-	apply automate_def2 with qa d; auto with v62.
+	apply chemin_D_chemin with qd qa g0; auto.
+	apply dans_trans with qd; auto.
+	apply automate_def2 with qa d; auto.
 
 intros.
-apply chemin_A_e1_g0 with q qd qa d g0 g0 g0; auto with v62.
+apply chemin_A_e1_g0 with q qd qa d g0 g0 g0; auto.
 Qed.
 
 (*									*)
@@ -1491,7 +1491,7 @@ cut (exists g0 : Elt, ~ dans g0 q).
 intro Ht; elim Ht; clear Ht; intros g0 H1.
 
 cut (automate_A (add g0 q) (singleton g0) qa (union d (delta_D g0 qd))).
-2: apply automate_A_D; auto with v62.
+2: apply automate_A_D; auto.
 intro.
 unfold isregular_D in |- *.
 exists (add g0 q).
@@ -1499,21 +1499,21 @@ exists g0.
 exists (sync_qa (add g0 q) qa (union d (delta_D g0 qd))).
 exists (sync_d (add g0 q) (union d (delta_D g0 qd))).
 split.
-apply automateA_automate; auto with v62.
+apply automateA_automate; auto.
 cut
  (eqwordset (reconnait q qd qa d)
     (reconnait_A (add g0 q) (singleton g0) qa (union d (delta_D g0 qd))) /\
   (forall w : Word,
    chemin_A (add g0 q) (union d (delta_D g0 qd)) g0 g0 w -> w = nil :>Word)). 
-2: apply isregular_isregular_D_1; auto with v62.
+2: apply isregular_isregular_D_1; auto.
 intro Ht; elim Ht; clear Ht; intros.
 split.
 
 	intros w H5.
 	cut (chemin_A (add g0 q) (union d (delta_D g0 qd)) g0 g0 w).
-	2: apply chemin_cheminA with (singleton g0) qa; auto with v62.
+	2: apply chemin_cheminA with (singleton g0) qa; auto.
 	intro.
-	apply (H4 w); auto with v62.
+	apply (H4 w); auto.
 
 	apply
   eqwordset_trans
@@ -1522,9 +1522,9 @@ split.
 	intro w.
 	split.
 	intro.
-	apply reconnait_reconnaitA; auto with v62.
+	apply reconnait_reconnaitA; auto.
 	intro.
-	apply reconnaitA_reconnait; auto with v62.
-	apply eqwordset_trans with (reconnait q qd qa d); auto with v62.
+	apply reconnaitA_reconnait; auto.
+	apply eqwordset_trans with (reconnait q qd qa d); auto.
 	apply eqwordset_sym; assumption.
 Qed.

--- a/Relations.v
+++ b/Relations.v
@@ -124,7 +124,7 @@ Lemma Rstar_inv :
 intros x y Rstar_x_y.
 pattern x, y in |- *.
 apply Rstar_x_y.
-	auto with v62.
+	auto.
 
 	intros u v w R_u_v Hyp.
 	apply or_intror.
@@ -142,4 +142,4 @@ Qed.
 
 End Relations.
 
-Hint Resolve Rstar_reflexive: v62.
+Hint Resolve Rstar_reflexive.

--- a/Words.v
+++ b/Words.v
@@ -52,8 +52,8 @@ Inductive inmonoid (X : Ensf) : Word -> Prop :=
   | inmonoid_cons :
       forall (w : Word) (e : Elt),
       inmonoid X w -> dans e X -> inmonoid X (cons e w).
-Hint Resolve inmonoid_nil: v62.
-Hint Resolve inmonoid_cons: v62.
+Hint Resolve inmonoid_nil.
+Hint Resolve inmonoid_cons.
 
 (*  Inversion de la definition 						*)
 (*
@@ -75,48 +75,48 @@ elim H.
 red in |- *; simpl in |- *; exact I.
 intros.
 change (dans e X /\ Inmonoid X w0) in |- *.
-auto with v62.
+auto.
 Qed.
-Hint Resolve i_I: v62.
+Hint Resolve i_I.
 
 Lemma I_i : forall (X : Ensf) (w : Word), Inmonoid X w -> inmonoid X w.
 intros X.
 simple induction w.
-auto with v62.
+auto.
 intros x w0 H H0.
-cut (dans x X /\ Inmonoid X w0); auto with v62.
+cut (dans x X /\ Inmonoid X w0); auto.
 intro H1; elim H1; clear H1.
-auto with v62.
+auto.
 Qed.
-Hint Resolve I_i: v62.
+Hint Resolve I_i.
 
 Lemma inmonoid_cons_inv :
  forall (X : Ensf) (w : Word) (a : Elt),
  inmonoid X (cons a w) -> inmonoid X w.
 intros.
-cut (Inmonoid X w); auto with v62.
-cut (Inmonoid X (cons a w)); auto with v62.
+cut (Inmonoid X w); auto.
+cut (Inmonoid X (cons a w)); auto.
 intro H0.
-cut (dans a X /\ Inmonoid X w); auto with v62.
+cut (dans a X /\ Inmonoid X w); auto.
 intro H1; elim H1; clear H1.
-auto with v62.
+auto.
 Qed.
 
 Lemma inmonoid_cons_inv2 :
  forall (X : Ensf) (a : Elt) (w : Word), inmonoid X (cons a w) -> dans a X.
 intros.
-cut (Inmonoid X (cons a w)); auto with v62.
+cut (Inmonoid X (cons a w)); auto.
 intro.
-cut (dans a X /\ Inmonoid X w); auto with v62.
+cut (dans a X /\ Inmonoid X w); auto.
 intro H1; elim H1; clear H1.
-auto with v62.
+auto.
 Qed.
 
 Lemma inmonoid_inclus :
  forall (E F : Ensf) (x : Word), inclus E F -> inmonoid E x -> inmonoid F x.
 intros E F x inclus_E_F inmonoid_E_x.
 elim inmonoid_E_x.
-        trivial with v62.
+        trivial.
  
         intros w e inmonoid_E_w inmonoid_F_w dans_e_E.
         apply inmonoid_cons; [ assumption | apply inclus_E_F; assumption ].
@@ -146,10 +146,10 @@ Fixpoint Append (w1 : Word) : Word -> Word :=
 
 Lemma Append_w_nil : forall w : Word, Append w nil = w :>Word.
 simple induction w.
-auto with v62.
+auto.
 intros x w0 H.
-replace (Append (cons x w0) nil) with (cons x (Append w0 nil)); auto with v62.
-rewrite H; auto with v62.
+replace (Append (cons x w0) nil) with (cons x (Append w0 nil)); auto.
+rewrite H; auto.
 Qed.
 
 Inductive append : Word -> Word -> Word -> Prop :=
@@ -165,26 +165,26 @@ Lemma Append_inmonoid_g :
  forall (X : Ensf) (w1 w2 : Word), inmonoid X (Append w1 w2) -> inmonoid X w1.
 intros X.
 simple induction w1.
-auto with v62.
+auto.
 intros x w H w2.
-replace (Append (cons x w) w2) with (cons x (Append w w2)); auto with v62.
+replace (Append (cons x w) w2) with (cons x (Append w w2)); auto.
 intro.
 apply inmonoid_cons.
 apply (H w2).
-apply inmonoid_cons_inv with x; auto with v62.
-apply inmonoid_cons_inv2 with (Append w w2); auto with v62.
+apply inmonoid_cons_inv with x; auto.
+apply inmonoid_cons_inv2 with (Append w w2); auto.
 Qed.
 
 Lemma Append_inmonoid_d :
  forall (X : Ensf) (w1 w2 : Word), inmonoid X (Append w1 w2) -> inmonoid X w2.
 intros X.
 simple induction w1.
-auto with v62.
+auto.
 intros x w H w2.
-replace (Append (cons x w) w2) with (cons x (Append w w2)); auto with v62.
+replace (Append (cons x w) w2) with (cons x (Append w w2)); auto.
 intro.
 apply (H w2).
-apply inmonoid_cons_inv with x; auto with v62.
+apply inmonoid_cons_inv with x; auto.
 Qed.
 
 Lemma inmonoid_Append :
@@ -192,13 +192,13 @@ Lemma inmonoid_Append :
  inmonoid X w1 -> inmonoid X w2 -> inmonoid X (Append w1 w2).
 intros X.
 simple induction w1.
-auto with v62.
+auto.
 intros x w H w2 H0 H1.
-replace (Append (cons x w) w2) with (cons x (Append w w2)); auto with v62.
+replace (Append (cons x w) w2) with (cons x (Append w w2)); auto.
 apply inmonoid_cons.
-apply (H w2); auto with v62.
-apply inmonoid_cons_inv with x; auto with v62.
-apply inmonoid_cons_inv2 with w; auto with v62.
+apply (H w2); auto.
+apply inmonoid_cons_inv with x; auto.
+apply inmonoid_cons_inv2 with w; auto.
 Qed.
 
 
@@ -217,14 +217,14 @@ Definition eqwordset (l1 l2 : wordset) : Prop :=
 
 Lemma eqwordset_refl : forall L : wordset, eqwordset L L.
 red in |- *.
-auto with v62.
+auto.
 Qed.
 
 Lemma eqwordset_sym :
  forall l1 l2 : wordset, eqwordset l1 l2 -> eqwordset l2 l1.
 unfold eqwordset in |- *.
 intros.
-elim (H w); clear H; intros; auto with v62.
+elim (H w); clear H; intros; auto.
 Qed.
 
 Lemma eqwordset_trans :
@@ -234,7 +234,7 @@ unfold eqwordset in |- *.
 intros.
 elim (H0 w); clear H0; intros.
 elim (H w); clear H; intros.
-auto with v62.
+auto.
 Qed.
 
 (*									*)
@@ -267,11 +267,11 @@ Lemma inmonoid_map :
  forall (f : Elt -> Elt) (a : Ensf) (w : Word),
  inmonoid a w -> inmonoid (map f a) (Word_ext f w).
 intros.
-elim H; [ unfold Word_ext in |- *; auto with v62 | idtac ].
+elim H; [ unfold Word_ext in |- *; auto | idtac ].
 intros; unfold Word_ext in |- *; simpl in |- *.
-apply inmonoid_cons; try apply dans_map_inv; auto with v62.
+apply inmonoid_cons; try apply dans_map_inv; auto.
 Qed.
-Hint Resolve inmonoid_map: v62.
+Hint Resolve inmonoid_map.
 
 (*  Un petit lemme bien utile par la suite...				*)
 
@@ -281,9 +281,9 @@ Lemma cons_cons :
 intros.
 rewrite H0.
 rewrite H.
-auto with v62.
+auto.
 Qed.
-Hint Resolve cons_cons: v62.
+Hint Resolve cons_cons.
 
 Definition fun_consaw_a (w : Word) : Elt :=
   match w return Elt with
@@ -306,28 +306,28 @@ Lemma cons_cons_inv :
  cons x1 w1 = cons x2 w2 -> x1 = x2 /\ w1 = w2.
 intros.
 split.
-replace x1 with (fun_consaw_a (cons x1 w1)); auto with v62.
-replace x2 with (fun_consaw_a (cons x2 w2)); auto with v62.
-apply (f_equal (A:=Word) (B:=Elt)); auto with v62.
-replace w1 with (fun_consaw_w (cons x1 w1)); auto with v62.
-replace w2 with (fun_consaw_w (cons x2 w2)); auto with v62.
-apply (f_equal (A:=Word) (B:=Word)); auto with v62.
+replace x1 with (fun_consaw_a (cons x1 w1)); auto.
+replace x2 with (fun_consaw_a (cons x2 w2)); auto.
+apply (f_equal (A:=Word) (B:=Elt)); auto.
+replace w1 with (fun_consaw_w (cons x1 w1)); auto.
+replace w2 with (fun_consaw_w (cons x2 w2)); auto.
+apply (f_equal (A:=Word) (B:=Word)); auto.
 Qed.
 
-Hint Resolve cons_cons_inv: v62.
+Hint Resolve cons_cons_inv.
 
 Lemma cons_cons_inv1 :
  forall (x1 x2 : Elt) (w1 w2 : Word),
  cons x1 w1 = cons x2 w2 :>Word -> x1 = x2 :>Elt.
 intros.
-cut (x1 = x2 :>Elt /\ w1 = w2 :>Word); [ intuition | auto with v62 ].
+cut (x1 = x2 :>Elt /\ w1 = w2 :>Word); [ intuition | auto ].
 Qed.
 
 
 Lemma cons_cons_inv2 :
  forall (x1 x2 : Elt) (w1 w2 : Word), cons x1 w1 = cons x2 w2 -> w1 = w2.
 intros.
-cut (x1 = x2 /\ w1 = w2); [ intuition | auto with v62 ].
+cut (x1 = x2 /\ w1 = w2); [ intuition | auto ].
 Qed.
 
 
@@ -340,11 +340,11 @@ Lemma nil_or_cons :
  w = nil \/ (exists x : Elt, (exists w0 : Word, w = cons x w0)).
 simple induction w.
 
-left; auto with v62.
+left; auto.
 
 intros x w0 H.
 right.
 exists x.
 exists w0.
-auto with v62.
+auto.
 Qed.

--- a/extract.v
+++ b/extract.v
@@ -90,7 +90,7 @@ cut (l_egal L LL).
 intro temp; elim temp.
 unfold l_inclus in |- *.
 intros.
-auto with v62.
+auto.
 unfold L, LL, wa, wd, d, f_R_d, f_X_d in |- *.
 apply equiv_APD_Gram.
 exact H.
@@ -104,7 +104,7 @@ cut (l_egal L LL).
 intro temp; elim temp.
 unfold l_inclus in |- *.
 intros.
-auto with v62.
+auto.
 unfold L, LL, wa, wd, d, f_R_d, f_X_d in |- *.
 apply equiv_APD_Gram.
 exact H.

--- a/fonctions.v
+++ b/fonctions.v
@@ -42,9 +42,9 @@ Require Import Ensf.
 Require Import Words.
 Require Import more_words.
 Require Import need.
-Hint Resolve dans_map_inv: v62.
-Hint Resolve dans_map: v62.
-Hint Resolve dans_add1: v62.
+Hint Resolve dans_map_inv.
+Hint Resolve dans_map.
+Hint Resolve dans_add1.
 
 Definition comp (f g : Elt -> Elt) (x : Elt) := f (g x).
 
@@ -52,7 +52,7 @@ Lemma map_map_eg_map_comp :
  forall (f g : Elt -> Elt) (E : Ensf),
  map f (map g E) = map (comp f g) E :>Ensf.
 intros f g.
-simple induction E; simpl in |- *; auto with v62.
+simple induction E; simpl in |- *; auto.
 Qed.
 
 
@@ -66,9 +66,9 @@ Lemma comp_Word_ext :
  eg_f_W_W (Word_ext (comp f g)) (comp_word (Word_ext f) (Word_ext g)).
 intros f g.
 unfold eg_f_W_W, Word_ext, comp, comp_word in |- *.
-simple induction x; simpl in |- *; auto with v62.
+simple induction x; simpl in |- *; auto.
 Qed.
-Hint Resolve comp_Word_ext: v62.
+Hint Resolve comp_Word_ext.
 
 Definition Id (E : Ensf) (f : Elt -> Elt) :=
   forall x : Elt, dans x E -> f x = x :>Elt.
@@ -76,28 +76,28 @@ Definition Id (E : Ensf) (f : Elt -> Elt) :=
 Lemma Id_inv :
  forall (E : Ensf) (f : Elt -> Elt) (x : Elt),
  dans x E -> Id E f -> f x = x :>Elt.
-auto with v62.
+auto.
 Qed.
 
-Hint Unfold Id: v62.
+Hint Unfold Id.
 
 Lemma Id_inclus :
  forall (E F : Ensf) (f : Elt -> Elt), inclus F E -> Id E f -> Id F f.
-auto with v62.
+auto.
 Qed.
 
 Lemma map_Id :
  forall (E : Ensf) (f : Elt -> Elt), Id E f -> map f E = E :>Ensf.
 intros E f.
  elim E; unfold map in |- *.
- auto with v62.
+ auto.
 
  intros a b Hyp_rec Id_a_b_f.
  apply add_add.
-	auto with v62.
+	auto.
 
  	apply Hyp_rec.
-	apply Id_inclus with (add a b); auto with v62.
+	apply Id_inclus with (add a b); auto.
 Qed.
 
 
@@ -108,7 +108,7 @@ Lemma Id_words_inv :
  forall (E : Ensf) (f : Word -> Word) (x : Word),
  inmonoid E x -> Id_words E f -> f x = x :>Word.
 
-auto with v62.
+auto.
 Qed.
 
 
@@ -128,7 +128,7 @@ Lemma extension_Id :
 intros E f Id_E_f.
 red in |- *.
 simple induction x; clear x.
-	auto with v62.
+	auto.
 
         unfold Word_ext in |- *.
 	(* plus simple :
@@ -156,7 +156,7 @@ Variable f : Elt -> Elt.
 
 Definition application := forall x : Elt, dans x E -> dans (f x) F.
 
-Hint Unfold application: v62.
+Hint Unfold application.
 
 (*Definition de l'injectivite*)
 
@@ -176,7 +176,7 @@ Definition is_iso := is_epi /\ is_mono.
 
 
 Lemma mono_epi_imp_iso : is_mono -> is_epi -> is_iso.
-intros; red in |- *; auto with v62.
+intros; red in |- *; auto.
 Qed.
 
 
@@ -208,13 +208,13 @@ Definition is_epi_words :=
 Definition is_iso_words := is_mono_words /\ is_epi_words.
 
 Lemma mono_epi_imp_iso_words : is_mono_words -> is_epi_words -> is_iso_words.
-intros; red in |- *; auto with v62.
+intros; red in |- *; auto.
 Qed.
 
 End fonctions.
 
 
-Hint Resolve mono_epi_imp_iso: v62.
+Hint Resolve mono_epi_imp_iso.
 
 
 Parameter inv : Ensf -> Ensf -> (Elt -> Elt) -> Elt -> Elt.
@@ -223,30 +223,30 @@ Axiom
   dans_inv_f :
     forall (E F : Ensf) (f : Elt -> Elt),
     is_iso E F f -> forall x : Elt, dans x F -> dans (inv E F f x) E.
-Hint Resolve dans_inv_f: v62.
+Hint Resolve dans_inv_f.
 
 Axiom
   inv1 :
     forall (E F : Ensf) (f : Elt -> Elt),
     is_iso E F f -> forall x : Elt, dans x E -> inv E F f (f x) = x :>Elt.
 
-Hint Resolve inv1: v62.
+Hint Resolve inv1.
 
 Axiom
   inv2 :
     forall (E F : Ensf) (f : Elt -> Elt),
     is_iso E F f -> forall x : Elt, dans x F -> f (inv E F f x) = x :>Elt.
 
-Hint Resolve inv2: v62.
+Hint Resolve inv2.
 
 Lemma inv1' :
  forall (E F : Ensf) (f : Elt -> Elt),
  is_iso E F f -> Id E (comp (inv E F f) f).
 unfold Id, comp in |- *.
 intros.
-auto with v62.
+auto.
 Qed.
-Hint Resolve inv1': v62.
+Hint Resolve inv1'.
 (* On etend la fonction f : Elt-> Elt definie sur V*)
 (*en la fonction F=(extension V f)*)
 (*definie sur Elt par F(x) = f(x) sur V et F(x)=x ailleurs*)
@@ -301,11 +301,11 @@ Variable E : Ensf.
 Variable F : Ensf.
 Variable f : Elt -> Elt.
 
-Hint Unfold application: v62.
+Hint Unfold application.
 Lemma is_epi_f_over_image : is_epi E (map f E) f.
 
 split.
- auto with v62.
+ auto.
 
 
  intros.
@@ -315,21 +315,21 @@ split.
 
 	prolog [ ex_intro2 ] 4.
 	(*Intros y temp; Elim temp; Clear temp ; Intros dans_y egal_y.
-	Exists y;Auto with v62.*)
+	Exists y;Auto.*)
 
- 	auto with v62.
+ 	auto.
 
 Qed.
 
-Hint Resolve is_epi_f_over_image: v62.
+Hint Resolve is_epi_f_over_image.
 
 Lemma mono_imp_iso_over_image : is_mono E f -> is_iso E (map f E) f.
-auto with v62.
+auto.
 Qed.
 
 Let invf := inv E F f.
 
-Hint Unfold invf: v62.
+Hint Unfold invf.
 
 Lemma inv_is_mono : is_iso E F f -> is_mono F invf.
 intros.
@@ -338,8 +338,8 @@ intros x y dans_x dans_y egal_inv.
 replace x with (f (inv E F f x)).
 replace y with (f (inv E F f y)).
 apply (f_equal (A:=Elt) (B:=Elt)); assumption.
-auto with v62.
-auto with v62.
+auto.
+auto.
 Qed.
 
 
@@ -347,13 +347,13 @@ Lemma inv_is_epi : is_iso E F f -> is_epi F E invf.
 unfold invf in |- *.
 intro is_iso_f.
 split.
- auto with v62. (* Hint : dans_inv_f*)
+ auto. (* Hint : dans_inv_f*)
 
-(* Hints Resolve inv1 : v62.*)
+(* Hints Resolve inv1 .*)
  intros x dans_x.
- exists (f x); [ apply sym_equal; auto with v62 | elim is_iso_f ].
+ exists (f x); [ apply sym_equal; auto | elim is_iso_f ].
  intros is_epi_f. elim is_epi_f.
- auto with v62.
+ auto.
 
 Qed.
 
@@ -364,14 +364,14 @@ Lemma application_imp_application_words :
 intro Hyp.
 red in |- *.
 intros x inmon; elim inmon; clear inmon.
-	auto with v62.
+	auto.
 
 	intros.
-	replace (wef (cons e w)) with (cons (f e) (wef w)); auto with v62.
+	replace (wef (cons e w)) with (cons (f e) (wef w)); auto.
 
 Qed.
 
-Hint Resolve application_imp_application_words: v62.
+Hint Resolve application_imp_application_words.
 
 Lemma is_mono_f_imp_is_mono_words : is_mono E f -> is_mono_words E wef.
 intro Hyp.
@@ -380,7 +380,7 @@ simple induction x.
 	intros.
 	apply sym_equal.
 	apply wef_nil with f.
-	auto with v62.
+	auto.
 
 	intros x0 w0. intros.
 	cut
@@ -395,32 +395,32 @@ simple induction x.
 	intros.
 	rewrite <- y_egal.
 	apply cons_cons.
-	apply Hyp. (*; Auto with v62.*)
+	apply Hyp. (*; Auto.*)
 	apply inmonoid_cons_inv2 with w0; assumption.
 	apply inmonoid_cons_inv2 with r; rewrite y_egal; assumption.
-	auto with v62.
+	auto.
 	apply H.
 		apply (inmonoid_cons_inv E w0 x0); assumption.
 		apply (inmonoid_cons_inv E r e); rewrite y_egal; assumption.
-		auto with v62.
+		auto.
 
 	(*Resolution du Cut*)
 	unfold wef in |- *.
 (*	Apply wef_cons.*)
-	auto with v62.
+	auto.
 Qed.
 
-Hint Resolve is_mono_f_imp_is_mono_words: v62.
+Hint Resolve is_mono_f_imp_is_mono_words.
 
 Lemma is_epi_f_imp_is_epi_words : is_epi E F f -> is_epi_words E F wef.
 intro temp; elim temp; clear temp.
 intro application_f.
 intro is_epi_f.
 split.
-auto with v62.
+auto.
 
 simple induction x; clear x.
-	exists nil; auto with v62.
+	exists nil; auto.
 
 	intros x w Hyp inmonoid_F_cons.
 	cut (exists2 y : Word, w = wef y & inmonoid E y). (*1*)
@@ -431,9 +431,9 @@ simple induction x; clear x.
 	intros x_ant x_egal dans_x_ant.
 	exists (cons x_ant y1).
 		unfold wef, Word_ext in |- *.
-		auto with v62.
+		auto.
 		
-		auto with v62. (* inmonoid_cons *)
+		auto. (* inmonoid_cons *)
 	(*Cut2*)
 	prolog [ inmonoid_cons_inv2 ] 3.     (*Apply is_epi_f.
 		Apply inmonoid_cons_inv2 with w; Assumption.*)
@@ -444,12 +444,12 @@ simple induction x; clear x.
 
 Qed.
 
-Hint Resolve is_epi_f_imp_is_epi_words: v62.
+Hint Resolve is_epi_f_imp_is_epi_words.
 
 Lemma is_iso_f_imp_is_iso_words : is_iso E F f -> is_iso_words E F wef.
 intro is_iso_f.
 elim is_iso_f; intros.
-split; auto with v62.
+split; auto.
 Qed.
 
 Let invf' := inv E F f.
@@ -475,13 +475,13 @@ generalize x.
 change (Id_words E (Word_ext (comp invf' f))) in |- *.
 apply extension_Id.
 unfold invf' in |- *.
-auto with v62.
+auto.
 
 (*Cut*)
-auto with v62.
+auto.
 Qed.
 
 
 
 End fonctions2.
-Hint Resolve mono_imp_iso_over_image: v62.
+Hint Resolve mono_imp_iso_over_image.

--- a/gram.v
+++ b/gram.v
@@ -77,7 +77,7 @@ replace x with x0; prolog [ sym_equal couple_couple_inv1 ] 3.
 	Apply sym_equal.
 	Apply couple_couple_inv1 with y (word u); Assumption.*)
 
-auto with v62.
+auto.
 Qed.
 
 Lemma Regles_inv2 :
@@ -95,8 +95,8 @@ intros u0 eg_couple inmonoid_u0.
 replace u with u0; prolog [ sym_equal couple_couple_inv2 word_word_inv ] 4.
 	(*Assumption.
 	Apply word_word_inv.
-	Apply couple_couple_inv2 with x0 x;Auto with v62.*)
-(**) auto with v62.
+	Apply couple_couple_inv2 with x0 x;Auto.*)
+(**) auto.
 Qed.
 
 
@@ -118,7 +118,7 @@ Let H := isGram X V R S.
 Lemma isGram1 : H -> Mots X.
 intro H1.
 elim H1.
-trivial with v62.
+trivial.
 Qed.
 
 Lemma isGram2 : H -> inter X V empty.
@@ -143,7 +143,7 @@ Qed.
 Lemma isGram5 : Mots X -> inter X V empty -> dans S V -> Regles X V R -> H.
 intros.
 red in |- *; red in |- *.
-auto with v62.
+auto.
 Qed.
 
 
@@ -153,7 +153,7 @@ End Easy_lemma_isGram.
 Lemma Regles_R :
  forall X V R R' : Ensf, inclus R' R -> Regles X V R -> Regles X V R'.
 unfold Regles in |- *.
-auto with v62.
+auto.
 Qed.
 
 Lemma Regles_V :
@@ -164,10 +164,10 @@ elim (Regles_X_V_R x dans_x_R).
 intros A dans_A_V temp; elim temp; clear temp.
 intros B egal_B inmonoid_B.
 exists A.
-auto with v62.
+auto.
 exists B.
 assumption.
-apply inmonoid_inclus with (union X V); auto with v62.
+apply inmonoid_inclus with (union X V); auto.
 Qed.
 
 
@@ -184,14 +184,14 @@ intuition.
 (*	Intro egal_x_couple.*)
 	exists a.
 		assumption.
-		exists u; auto with v62.
+		exists u; auto.
 (**)apply dans_add; assumption.
 Qed.
 
 Lemma Regles_add2 :
  forall (X V R : Ensf) (a : Elt), Regles X V R -> Regles X (add a V) R.
 intros.
-apply Regles_V with V; auto with v62.
+apply Regles_V with V; auto.
 Qed.
 
 
@@ -201,7 +201,7 @@ Lemma Regles_union :
 
 unfold Regles in |- *.
 intros X V R R' R_R R_R' x dans_x_union.
-cut (dans x R \/ dans x R'); auto with v62.
+cut (dans x R \/ dans x R'); auto.
 intros [HR| HR']; auto.
 Qed.
 
@@ -223,7 +223,7 @@ Qed.
 Lemma isGram_inclus3 :
  forall (X V R : Ensf) (S a : Elt), isGram X V (add a R) S -> isGram X V R S.
 intros X V R S a isGram_X_V_a_R_S.
-apply isGram_inclus2 with (add a R); auto with v62.
+apply isGram_inclus2 with (add a R); auto.
 Qed.
 
 
@@ -245,15 +245,15 @@ Inductive Derive (R : Ensf) : Word -> Word -> Prop :=
       forall (u v : Word) (x : Elt),
       Derive R u v -> Derive R (cons x u) (cons x v).
 
-Hint Resolve Derive1: v62.
-Hint Resolve Derive2: v62.
+Hint Resolve Derive1.
+Hint Resolve Derive2.
 
 
 Lemma Derive_inclus :
  forall (R1 R2 : Ensf) (u v : Word),
  inclus R1 R2 -> Derive R1 u v -> Derive R2 u v.
 intros R1 R2 u v inclus_R1_R2 Der_R1.
-elim Der_R1; auto with v62.
+elim Der_R1; auto.
 Qed.
 
 
@@ -283,10 +283,10 @@ elim Der_x_y; prolog [ ex_intro2 refl_equal or_intror or_introl ] 8.
 
  Intros u v x0 Der_u_v Der_inv_u_v.
  Simpl; Right.
- Exists v; Trivial with v62.*)
+ Exists v; Trivial .*)
 Qed.
 
-Hint Resolve Derive_inv1: v62.
+Hint Resolve Derive_inv1.
 
 Lemma Derive_inv2 :
  forall (R : Ensf) (x y : Word),
@@ -309,7 +309,7 @@ intros x0 w Hyp_rec.
 unfold Derive_inv in |- *.
 (*Simpl.*)
 exists x0.
-exists w; trivial with v62.
+exists w; trivial.
 Qed.
 
 
@@ -361,13 +361,13 @@ Qed.
 
 Definition Derivestar (R : Ensf) := Rstar Word (Derive R).
 
-Hint Unfold Derivestar: v62.
+Hint Unfold Derivestar.
 
 Lemma Derivestar_refl : forall (R : Ensf) (u : Word), Derivestar R u u.
-auto with v62.
+auto.
 Qed.
 
-Hint Resolve Derivestar_refl: v62.
+Hint Resolve Derivestar_refl.
 
 Lemma Derivestar_R :
  forall (R : Ensf) (u v w : Word),
@@ -389,7 +389,7 @@ prolog [ Rstar_inv ] 6.
 Apply Rstar_inv;Assumption.*)
 Qed.
 
-Hint Resolve Derivestar_inv: v62.
+Hint Resolve Derivestar_inv.
 
 
 Lemma Derivestar_inclus :
@@ -399,7 +399,7 @@ intros R1 R2 u v inclus_R1_R2 Der_R1.
 unfold Derivestar, Rstar in Der_R1.
 pattern u, v in |- *.
 apply Der_R1.
-	auto with v62.
+	auto.
 	intros; prolog [ Derive_inclus Derivestar_R ] 3.
 	(*Intros a b c Der_a_b Der_b_c.
 	Apply Derivestar_R with b.
@@ -418,14 +418,14 @@ Lemma LG_inv :
  forall (X V R : Ensf) (S : Elt) (w : Word), LG X V R S w -> inmonoid X w.
 unfold LG in |- *.
 intros.
-elim H; auto with v62.
+elim H; auto.
 Qed.
 
 (*Pour toute grammaire (X,V,R,S), (LG X V R S) est un langage *)
 
 Lemma LG_langage :
  forall (X V R : Ensf) (S : Elt), isGram X V R S -> islanguage X (LG X V R S).
-intros; red in |- *; intros; elim H0; auto with v62.
+intros; red in |- *; intros; elim H0; auto.
 Qed.
 
 

--- a/gram2.v
+++ b/gram2.v
@@ -46,7 +46,7 @@ Require Import fonctions.
 Require Import Relations.
 Require Import gram.
 
-Hint Resolve extension_Id: v62.
+Hint Resolve extension_Id.
 Section resultats.
 
 
@@ -80,9 +80,9 @@ unfold Ru in |- *; unfold C in |- *; unfold Gunion in |- *; simpl in |- *.
 apply Regles_union; unfold Vu in |- *; unfold C in |- *;
  unfold Gunion in |- *; simpl in |- *.
 apply Regles_V with V1;
- [ auto with v62 | apply isGram4 with S1; auto with v62 ].
+ [ auto | apply isGram4 with S1; auto ].
 apply Regles_V with V2;
- [ auto with v62 | apply isGram4 with S2; auto with v62 ].
+ [ auto | apply isGram4 with S2; auto ].
 Qed.
 
 
@@ -97,7 +97,7 @@ elim Der_Ru_u.
 	apply Derive1.
 	cut (dans (couple A (word u0)) R1 \/ dans (couple A (word u0)) R2). (**)
 	intro temp; elim temp; clear temp.
-		auto with v62.
+		auto.
 
 		intro dans_R2.
 		absurd (inter (union X V1) V2 empty).
@@ -168,7 +168,7 @@ unfold Derivestar in |- *.
 intros G_1 G_2 inter_V1_V2_empty u v Derivestar_Ru.
 pattern u, v in |- *.
 apply Derivestar_Ru.
-	auto with v62. (*Intros.
+	auto. (*Intros.
 	Apply Rstar_reflexive.*)
 
 	intros u0 v0 w Der_Ru inmon_v0_imp_Rstar_R1_v0 inmon_u0. 
@@ -223,9 +223,9 @@ prolog [ inmonoid_cons_inv2 Regles_inv1 ] 3.
 *)
 		assumption.
 
-	trivial with v62.
+	trivial.
 
-	(**) auto with v62.
+	(**) auto.
 
 	prolog [ Derive2 inmonoid_cons_inv ] 10.
 (*	Intros u0 v0 x Der_Ru imp inmon_cons_x_u0.
@@ -301,7 +301,7 @@ unfold Derivestar in |- *.
 intros G_1 G_2 inter_V1_V2_empty u v Derivestar_Ru.
 pattern u, v in |- *.
 apply Derivestar_Ru.
-	auto with v62. (*Intros.
+	auto. (*Intros.
 	Apply Rstar_reflexive.*)
 
 	intros u0 v0 w Der_Ru inmon_v0_imp_Rstar_R2_v0 inmon_u0. 
@@ -363,9 +363,9 @@ Lemma dans_Rim :
 intros.
 unfold Rim, Gim3, Gim2, Gim, imageGram in |- *; simpl in |- *.
 replace (couple (f A) (word (wef u))) with (fonc (couple A (word u)));
- auto with v62.
+ auto.
 Qed.
-Hint Resolve dans_Rim: v62.
+Hint Resolve dans_Rim.
 
 Lemma image_Regles : Regles X V1 R1 -> Regles Xim Vim Rim.
 unfold Rim, Vim, Xim, Gim3, Gim2, Gim, imageGram, Regles in |- *;
@@ -383,9 +383,9 @@ exists (f A_ant).
 	rewrite x_egal; unfold fonc in |- *; unfold fet in |- *.
 	rewrite x_ant_egal; unfold first in |- *; unfold second in |- *;
   unfold word_inv in |- *; simpl in |- *.
-	trivial with v62.
+	trivial.
 	replace (union (map f X) (map f V1)) with (map f (union X V1));
-  auto with v62.
+  auto.
 
 apply dans_map; assumption. (*1*)
 Qed.
@@ -412,21 +412,21 @@ Lemma Id_image_X : Id (union X V1) f -> Xim = X :>Ensf.
 
 unfold Xim, Gim, imageGram in |- *; simpl in |- *.
 elim X.
-auto with v62.
+auto.
 (* Clear X. *)
 intros a X' Hyp Id_a_X_V1_f.
 unfold map in |- *.
 simpl in |- *.
 apply add_add.
-	auto with v62.
+	auto.
 
 	apply Hyp.
 	apply Id_inclus with (union (add a X') V1).
 
 		red in |- *; intros x dans_x_union_X_V1.
 		cut (dans x X' \/ dans x V1). 
-	        intros [HX| HV1]; auto with v62.
-		auto with v62.
+	        intros [HX| HV1]; auto.
+		auto.
 
 		assumption.
 Qed.
@@ -439,14 +439,14 @@ intros a V1' Hyp Id_X_a_V1_f.
 unfold map in |- *.
 simpl in |- *.
 apply add_add.
-	auto with v62.
+	auto.
 
 	apply Hyp.
 	apply Id_inclus with (union X (add a V1')).
 		red in |- *; intros x dans_x_union_X_V1.
 		cut (dans x X \/ dans x V1'). 
-		intros [HX| HV1]; auto with v62.
-		auto with v62.
+		intros [HX| HV1]; auto.
+		auto.
 					
 		assumption.
 Qed.
@@ -456,7 +456,7 @@ intros Id_X_V1_f.
 
 unfold Rim, Gim3, Gim2, Gim, imageGram in |- *; simpl in |- *.
 elim R1.
-auto with v62.
+auto.
 intros a R Hyp isGram_X_V1_R1_S1.
 unfold map in |- *.
 simpl in |- *.
@@ -471,15 +471,15 @@ apply add_add.
 
 	rewrite egal_a.
 	apply couple_couple; unfold first, second, word_inv in |- *; simpl in |- *.
-		auto with v62.
+		auto.
 
 		apply word_word.
-		cut (Id_words (union X V1) (Word_ext f)); auto with v62.
+		cut (Id_words (union X V1) (Word_ext f)); auto.
 		
 
-	trivial with v62.
+	trivial.
 
-	apply isGram4 with S1; trivial with v62.
+	apply isGram4 with S1; trivial.
 
 	prolog [ isGram_inclus3 ] 3.
 	(*Apply Hyp.
@@ -522,19 +522,19 @@ elim H; clear H u v.
 	intros u v A dans_A.
 	replace (wef (cons A v)) with (cons (f A) (wef v)).
 	replace (wef (Append u v)) with (Append (wef u) (wef v)).
-	auto with v62.
+	auto.
 
-	apply sym_equal; unfold wef in |- *; apply wef_append; auto with v62.
+	apply sym_equal; unfold wef in |- *; apply wef_append; auto.
 
-	auto with v62.
+	auto.
 
 	intros.
 	replace (wef (cons x u)) with (cons (f x) (wef u)).
-	 replace (wef (cons x v)) with (cons (f x) (wef v)); auto with v62.
-	 auto with v62.
+	 replace (wef (cons x v)) with (cons (f x) (wef v)); auto.
+	 auto.
 Qed.
 
-Hint Resolve Derive_image: v62.
+Hint Resolve Derive_image.
 
 Lemma Derivestar_image :
  forall u v : Word, Derivestar R1 u v -> Derivestar Rim (wef u) (wef v).
@@ -543,12 +543,12 @@ intros u v Hyp.
 unfold Derivestar, Rstar in Hyp.
 pattern u, v in |- *.
 apply Hyp.
-	auto with v62. (*Intros; Apply Rstar_reflexive. *)
+	auto. (*Intros; Apply Rstar_reflexive. *)
 	intros a b c DeriveR1 Rst.
-	apply Rstar_R with (y := wef b); auto with v62.
+	apply Rstar_R with (y := wef b); auto.
 Qed.
 
-Hint Resolve Derivestar_image: v62.
+Hint Resolve Derivestar_image.
 
 
 Lemma Reconnait_imageGram :
@@ -558,19 +558,19 @@ intro w.
 unfold LG in |- *.
 intro temp; split; elim temp; clear temp; intros Der inmo.
 	unfold Sim, Gim3, Gim2, Gim, imageGram in |- *; simpl in |- *.
-	replace (cons (f S1) nil) with (wef (cons S1 nil)); auto with v62.
+	replace (cons (f S1) nil) with (wef (cons S1 nil)); auto.
 
 	elim inmo.
-		auto with v62.
+		auto.
 		intros wo el.
 		unfold Xim, Gim, imageGram in |- *; simpl in |- *.
-		replace (wef (cons el wo)) with (cons (f el) (wef wo)); auto with v62.
+		replace (wef (cons el wo)) with (cons (f el) (wef wo)); auto.
 Qed.
 
 
 End resultats.
 
-Hint Resolve dans_Rim: v62.
-Hint Resolve Derive_image: v62.
-Hint Resolve Derivestar_image: v62.
-Hint Resolve Reconnait_imageGram: v62.
+Hint Resolve dans_Rim.
+Hint Resolve Derive_image.
+Hint Resolve Derivestar_image.
+Hint Resolve Reconnait_imageGram.

--- a/gram3.v
+++ b/gram3.v
@@ -86,9 +86,9 @@ unfold Xim, Vim in |- *; simpl in |- *.
 red in |- *.
 (*Intuition.*) split; [ idtac | split ].
 
-auto with v62.
+auto.
 
-auto with v62.
+auto.
 
 intros x dans_x_map_f_X dans_x_map_f_V.
 elimtype (exists y : Elt, dans y X /\ x = f y :>Elt).
@@ -103,13 +103,13 @@ apply imp.
 replace v with x_ant.
 	assumption.
 	apply Mono.
-		auto with v62.
-		auto with v62.
+		auto.
+		auto.
 		rewrite <- x_egal_f_x_ant; assumption.
 assumption.
 exact (isGram2 X V R S Gram).
-auto with v62.
-auto with v62.
+auto.
+auto.
 Qed.
 
 
@@ -121,17 +121,17 @@ Qed.
 
 Lemma Iso : is_iso (union X V) (union Xim Vim) f.
 rewrite union_Xim_Vim_map_f_union_X_V.
-auto with v62.
+auto.
 Qed.
 
-Hint Resolve Iso: v62.
+Hint Resolve Iso.
 
 Let wef := Word_ext f.
 Let weinvf := Word_ext invf.
 
 Lemma invf_f : Id (union X V) (comp invf f).
 unfold invf in |- *.
-auto with v62.
+auto.
 Qed.
 
 Lemma weinvf_wef : Id_words (union X V) (comp_word weinvf wef).
@@ -171,10 +171,10 @@ unfold Gim' in |- *.
 unfold Sim, Rim, Gim3, Vim, Gim2, Xim, Gim, imageGram in |- *; simpl in |- *.
 
 apply pair_equal.
-rewrite (map_map_eg_map_comp invf f X); auto with v62.
+rewrite (map_map_eg_map_comp invf f X); auto.
 
 apply pair_equal.
-rewrite (map_map_eg_map_comp invf f V); auto with v62.
+rewrite (map_map_eg_map_comp invf f V); auto.
 
 apply pair_equal.
 
@@ -194,8 +194,8 @@ Lemma egalG : Gim' = (X, (V, (R, S))).
 rewrite egalGim'_image_comp.
 apply Id_image_G.
 unfold invf in |- *.
-auto with v62.
-auto with v62.
+auto.
+auto.
 Qed.
 
 
@@ -233,12 +233,12 @@ rewrite <- egalX.
 
 replace w with (weinvf (wef w)).
 	unfold Sim', Rim', Gim3', Vim', Gim2', Xim', Gim', weinvf in |- *.
-	auto with v62.
+	auto.
 	change (comp_word weinvf wef w = w :>Word) in |- *.
 	apply Id_words_inv with X.
 		assumption.
 		apply Id_words_inclus with (union X V).
-			auto with v62.
+			auto.
 			exact weinvf_wef.
 Qed.
 
@@ -260,7 +260,7 @@ split.
 	intros w LG_X_w.
 	replace w with (wef w).
 		unfold Sim, Rim, Gim3, Vim, Gim2, Xim, Gim, wef in |- *.
-		auto with v62.
+		auto.
 
 		apply (Id_words_inv X).
 			prolog [ LG_inv ] 2.
@@ -288,7 +288,7 @@ split.
 
 		apply Id_words_inv with (union X V).
 			apply inmonoid_inclus with X.
-				auto with v62.
+				auto.
 				replace X with Xim.
 				prolog [ LG_inv ] 2.
 				(*Apply LG_inv with Vim Rim Sim;Assumption.*)

--- a/gram4.v
+++ b/gram4.v
@@ -80,9 +80,9 @@ Lemma inter_X_Vu_d :
 intros G_1 G_2 N_dans_S_X.
 unfold inter in |- *.
 split.
- auto with v62.
+ auto.
  split.
-  auto with v62.
+  auto.
   intros x dans_x_X dans_x_Vu.
   absurd (dans x X).
   cut (S = x :>Elt \/ dans x (union V1 V2)). (**)
@@ -98,7 +98,7 @@ split.
 
 		Assumption.*)
 
-  (**)auto with v62.
+  (**)auto.
 
   assumption.
 Qed.
@@ -113,20 +113,20 @@ apply Regles_add2.
 change (Regles X (fst (Gunion V1 R1 V2 R2)) (snd (Gunion V1 R1 V2 R2)))
  in |- *.
 prolog [ Gunion_Regles ] 2.
-(*Apply Gunion_Regles with S1 S2;Auto with v62.*)
-auto with v62.
+(*Apply Gunion_Regles with S1 S2;Auto.*)
+auto.
 apply inmonoid_cons.
-trivial with v62.
+trivial.
 cut (dans S2 V2);
- [ auto with v62
+ [ auto
  | prolog [ isGram3 ] 2(*Apply isGram3 with X R2;Assumption*) ].
 
-auto with v62.
+auto.
 
 apply inmonoid_cons.
-trivial with v62.
+trivial.
 cut (dans S1 V1);
- [ auto with v62
+ [ auto
  | prolog [ isGram3 ] 2 (*Apply isGram3 with X R1;Assumption*) ].
 
 Qed.
@@ -159,7 +159,7 @@ elim Der_Ru_u.
 	replace S with A.
 	prolog [ inmonoid_cons_inv2 ] 2.
 	(*Apply inmonoid_cons_inv2 with v0;Assumption.*)
-	injection egal_S; auto with v62.
+	injection egal_S; auto.
 
 	intro dans_couple_add.
 	cut
@@ -169,18 +169,18 @@ elim Der_Ru_u.
 	intro egal_S.
 	absurd (dans S X \/ dans S V1).
 	red in |- *.
-	intro temp; elim temp; auto with v62.
+	intro temp; elim temp; auto.
 
 	apply dans_union.
 	replace S with A.
 	prolog [ inmonoid_cons_inv2 ] 2.
 	(*Apply inmonoid_cons_inv2 with v0;Assumption.*)
-	injection egal_S; auto with v62.
+	injection egal_S; auto.
 
 	intro dans_couple_union.	
 	cut (dans (couple A (word u0)) R1 \/ dans (couple A (word u0)) R2). (****)
 	(*Intuition.*)intro temp; elim temp; clear temp.
-		auto with v62.
+		auto.
 		intro dans_R2.
 		absurd (inter (union X V1) V2 empty).
 			red in |- *.
@@ -200,11 +200,11 @@ elim Der_Ru_u.
 						Assumption.*)
 		assumption.
 
-	(****)auto with v62.
+	(****)auto.
 
-	(***)auto with v62.
+	(***)auto.
 
-	(**)auto with v62.
+	(**)auto.
 
 	prolog [ inmonoid_cons_inv Derive2 ] 10.
 	(*Intros u0 v0 x Der_Ru imp inmon_cons_x_u0.
@@ -276,7 +276,7 @@ intros N_dans_X N_dans_V1 N_dans_V2 G_1 G_2 inter_V1_V2_empty u v
  Derivestar_Ru.
 pattern u, v in |- *.
 apply Derivestar_Ru.
-	auto with v62.
+	auto.
 
 	intros u0 v0 w Der_Ru inmon_v0_imp_Rstar_R1_v0 inmon_u0. 
 	apply Rstar_R with v0;
@@ -327,7 +327,7 @@ elim Der_Ru_u.
 	replace S with A.
 	prolog [ inmonoid_cons_inv2 ] 2.
 	(*Apply inmonoid_cons_inv2 with v0;Assumption.*)
-	injection egal_S; auto with v62.
+	injection egal_S; auto.
 
 	intro dans_couple_add.
 	cut
@@ -342,7 +342,7 @@ elim Der_Ru_u.
 	replace S with A.
 	prolog [ inmonoid_cons_inv2 ] 2.
 	(*Apply inmonoid_cons_inv2 with v0;Assumption.*)
-	injection egal_S; auto with v62.
+	injection egal_S; auto.
 
 	intro dans_couple_union.	
 	cut (dans (couple A (word u0)) R1 \/ dans (couple A (word u0)) R2). (****)
@@ -368,13 +368,13 @@ elim Der_Ru_u.
 		assumption.
 
 
-		trivial with v62.
+		trivial.
 		
-	(****)auto with v62.
+	(****)auto.
 
-	(***)auto with v62.
+	(***)auto.
 
-	(**)auto with v62.
+	(**)auto.
 
 	prolog [ inmonoid_cons_inv Derive2 ] 10.
 	(*Intros u0 v0 x Der_Ru imp inmon_cons_x_u0.
@@ -447,7 +447,7 @@ intros N_dans_X N_dans_V1 N_dans_V2 G_1 G_2 inter_V1_V2_empty u v
  Derivestar_Ru.
 pattern u, v in |- *.
 apply Derivestar_Ru.
-	auto with v62.
+	auto.
 
 	intros u0 v0 w Der_Ru inmon_v0_imp_Rstar_R2_v0 inmon_u0. 
 	apply Rstar_R with v0.
@@ -495,7 +495,7 @@ intro temp; elim temp; clear temp; intro temp; elim temp; clear temp.
      (add (couple S (word (cons S2 nil))) (union R1 R2))). (**)
 	intro temp; elim temp; clear temp.
 	intro egal_S.
-	injection egal_S; auto with v62.
+	injection egal_S; auto.
 	
 	intro dans_couple_add.
 	cut
@@ -503,7 +503,7 @@ intro temp; elim temp; clear temp; intro temp; elim temp; clear temp.
    dans (couple S (word x)) (union R1 R2)). (***)
 	intro temp; elim temp; clear temp.
 	intro egal_S.
-	injection egal_S; auto with v62.
+	injection egal_S; auto.
 	
 	intro dans_couple_union.	
 	cut (dans (couple S (word x)) R1 \/ dans (couple S (word x)) R2). (****)
@@ -524,11 +524,11 @@ intro temp; elim temp; clear temp; intro temp; elim temp; clear temp.
 			Apply isGram4 with S2;Assumption.
 			Assumption.*)
 
-	(****)auto with v62.
+	(****)auto.
 
-	(***)auto with v62.
+	(***)auto.
 
-	(**)auto with v62.
+	(**)auto.
 
 replace x with (Append x nil).
 replace nil with x0.
@@ -541,12 +541,12 @@ cut (Derive_inv Ru nil x).
 unfold Derive_inv in |- *.
 simpl in |- *.
 tauto.
-auto with v62.
+auto.
 
-auto with v62.
+auto.
 Qed.
 
-Hint Resolve Gunion_disj_Derive1: v62.
+Hint Resolve Gunion_disj_Derive1.
 
 
 
@@ -568,7 +568,7 @@ cut
   (exists2 w : Word, Derive Ru (cons S nil) w & Derivestar Ru w u)). (**)
 
 intro temp; elim temp; clear temp.
-	auto with v62.
+	auto.
 
 	intro temp; elim temp; clear temp.
 	intros x Der_Ru_cons_S_nil_x Derivestar_Ru_x_u.
@@ -578,42 +578,42 @@ intro temp; elim temp; clear temp.
 	intro temp; elim temp; clear temp; intro x_egal; rewrite x_egal.
 		apply or_introl.	
 		apply Gunion_disj_Derivestar;
-   [ auto with v62
-   | auto with v62
-   | auto with v62
-   | auto with v62
-   | auto with v62
-   | auto with v62
-   | auto with v62
+   [ auto
+   | auto
+   | auto
+   | auto
+   | auto
+   | auto
+   | auto
    | idtac ].
 			rewrite <- x_egal; cut (dans S1 V1).
-						auto with v62.
+						auto.
 						prolog [ isGram3 ] 2.
 						(*Apply isGram3 with X R1.
 						Assumption.*)
 
 		apply or_intror.	
 		apply Gunion_disj_Derivestar2;
-   [ auto with v62
-   | auto with v62
-   | auto with v62
-   | auto with v62
-   | auto with v62
-   | auto with v62
-   | auto with v62
+   [ auto
+   | auto
+   | auto
+   | auto
+   | auto
+   | auto
+   | auto
    | idtac ].
 			rewrite <- x_egal; cut (dans S2 V2).
-						auto with v62.
+						auto.
 						prolog [ isGram3 ] 2.
 						(*Apply isGram3 with X R2.
 						Assumption.*)
 
-	(***)auto with v62.
+	(***)auto.
 	
-(**)auto with v62.
+(**)auto.
 Qed.
 
-Hint Resolve Gunion_disj_Derivestar_S: v62.
+Hint Resolve Gunion_disj_Derivestar_S.
 
 
 Lemma Gunion_disj_LG_inclus1 :
@@ -638,9 +638,9 @@ elimtype
 		apply inmonoid_cons_inv2 with nil.
 		rewrite eg_cons_S_nil_w; assumption.
 
-	intro temp; elim temp; clear temp; auto with v62.
+	intro temp; elim temp; clear temp; auto.
 
-(**)auto with v62.
+(**)auto.
 Qed.
 
 Lemma Gunion_disj_LG_inclus2 : l_inclus (LG X V1 R1 S1) (LG X Vu Ru S).
@@ -652,11 +652,11 @@ unfold Ru in |- *; simpl in |- *.
 split.
 	apply Derivestar_R with (cons S1 nil).
 		replace (cons S1 nil) with (Append (cons S1 nil) nil).
-			auto with v62.
+			auto.
 			
-			auto with v62.
+			auto.
 
-		apply Derivestar_inclus with R1; auto with v62.
+		apply Derivestar_inclus with R1; auto.
 
 assumption.
 Qed.
@@ -671,11 +671,11 @@ unfold Ru in |- *; simpl in |- *.
 split.
 	apply Derivestar_R with (cons S2 nil).
 		replace (cons S2 nil) with (Append (cons S2 nil) nil).
-			auto with v62.
+			auto.
 			
-			auto with v62.
+			auto.
 
-		apply Derivestar_inclus with R2; auto with v62.
+		apply Derivestar_inclus with R2; auto.
 
 assumption.
 Qed.

--- a/gram5.v
+++ b/gram5.v
@@ -86,27 +86,27 @@ Let Su := snd C'.
 
 Hypothesis Grammaire1 : isGram X V1 R1 S1.
 Hypothesis Grammaire2 : isGram X V2 R2 S2.
-Hint Resolve Grammaire1: v62.
-Hint Resolve Grammaire2: v62.
+Hint Resolve Grammaire1.
+Hint Resolve Grammaire2.
 
 
 Lemma Mots_X : Mots X.
 apply isGram1 with V1 R1 S1.
-auto with v62.
+auto.
 Qed.
-Hint Resolve Mots_X: v62.
+Hint Resolve Mots_X.
 
 Lemma int_X_V1_empty : inter X V1 empty.
 apply isGram2 with R1 S1.
-auto with v62.
+auto.
 Qed.
-Hint Resolve int_X_V1_empty: v62.
+Hint Resolve int_X_V1_empty.
 
 Lemma int_X_V2_empty : inter X V2 empty.
 apply isGram2 with R2 S2.
-auto with v62.
+auto.
 Qed.
-Hint Resolve int_X_V2_empty: v62.
+Hint Resolve int_X_V2_empty.
 
 
 
@@ -124,9 +124,9 @@ unfold Id, injproducg in |- *.
 simpl in |- *.
 intros x dans_x_X.
 apply extension_out.
-apply inter_dans with X; auto with v62.
+apply inter_dans with X; auto.
 Qed.
-Hint Resolve Id_injproducg1: v62.
+Hint Resolve Id_injproducg1.
 
 
 Lemma Id_injproducd2 : forall x : Elt, dans x X -> injproducd V2 x = x :>Elt.
@@ -134,9 +134,9 @@ unfold Id, injproducd in |- *.
 simpl in |- *.
 intros x dans_x_X.
 apply extension_out.
-apply inter_dans with X; auto with v62.
+apply inter_dans with X; auto.
 Qed.
-Hint Resolve Id_injproducd2: v62.
+Hint Resolve Id_injproducd2.
 
 Lemma N_dans_S_X : ~ dans S' X.
 red in |- *.
@@ -147,7 +147,7 @@ elimtype (exists w : Word, word w = S').
 	discriminate.
 apply Mots_X; assumption.
 Qed.
-Hint Resolve N_dans_S_X: v62.
+Hint Resolve N_dans_S_X.
 
 Lemma injproducg_V1 :
  forall x : Elt, dans x V1 -> injproducg V1 x = injgauche x.
@@ -155,18 +155,18 @@ intros x dans_x_V1.
 unfold injproducg, extension in |- *.
 elim (extension_spec V1 injgauche x).
 intros x0 temp; elim temp; clear temp; intro temp; elim temp; clear temp.
-	auto with v62.
+	auto.
 	intros.
 	absurd (dans x V1); assumption.
 Qed.
-Hint Resolve injproducg_V1: v62.
+Hint Resolve injproducg_V1.
 
 
 Lemma map_injproducg_V1 : map (injproducg V1) V1 = map injgauche V1 :>Ensf.
 apply map_egal.
-auto with v62.
+auto.
 Qed.
-Hint Resolve map_injproducg_V1: v62.
+Hint Resolve map_injproducg_V1.
 
 Lemma injproducd_V2 :
  forall x : Elt, dans x V2 -> injproducd V2 x = injdroite x.
@@ -174,18 +174,18 @@ intros x dans_x_V2.
 unfold injproducd, extension in |- *.
 elim (extension_spec V2 injdroite x).
 intros x0 temp; elim temp; clear temp; intro temp; elim temp; clear temp.
-	auto with v62.
+	auto.
 	intros.
 	absurd (dans x V2); assumption.
 Qed.
-Hint Resolve injproducd_V2: v62.
+Hint Resolve injproducd_V2.
 
 
 Lemma map_injproducd_V2 : map (injproducd V2) V2 = map injdroite V2 :>Ensf.
 apply map_egal.
-auto with v62.
+auto.
 Qed.
-Hint Resolve map_injproducd_V2: v62.
+Hint Resolve map_injproducd_V2.
 
 
 
@@ -199,14 +199,14 @@ intros dans_x_V1 S_egal.
 absurd (S' = couple x zero).
 unfold S', zero in |- *.
 discriminate.
-auto with v62.
+auto.
 apply (dans_map (fun e : Elt => couple e zero)).
 assumption.
 unfold V1' in |- *.
 simpl in |- *.
-auto with v62.
+auto.
 Qed.
-Hint Resolve N_dans_S_V1': v62.
+Hint Resolve N_dans_S_V1'.
 
 
 Lemma N_dans_S_V2' : ~ dans S' V2'.
@@ -220,15 +220,15 @@ intros dans_x_V2 S_egal.
 absurd (S' = couple x un).
 unfold S', zero in |- *.
 discriminate.
-auto with v62.
+auto.
 apply (dans_map (fun e : Elt => couple e un)).
 assumption.
 unfold V2' in |- *.
 simpl in |- *.
-auto with v62.
+auto.
 Qed.
 
-Hint Resolve N_dans_S_V2': v62.
+Hint Resolve N_dans_S_V2'.
 
 Lemma is_mono_u_X_V1_injproducg_V1 : is_mono (union X V1) (injproducg V1).
 unfold is_mono in |- *.
@@ -240,8 +240,8 @@ replace (injproducg V1 x) with x.
 elimtype (dans y X \/ dans y V1).
 intros dans_y.
 replace (injproducg V1 y) with y.
-auto with v62.
-apply sym_equal; auto with v62.
+auto.
+apply sym_equal; auto.
 
 intros dans_y.
 replace (injproducg V1 y) with (injgauche y).
@@ -252,10 +252,10 @@ absurd (word x0 = couple y zero).
 	discriminate.
 	rewrite egal_x; assumption.
 
-apply sym_equal; auto with v62.
+apply sym_equal; auto.
 
-auto with v62.
-apply sym_equal; auto with v62.
+auto.
+apply sym_equal; auto.
 
 intro dans_x.
 replace (injproducg V1 x) with (injgauche x).
@@ -269,7 +269,7 @@ absurd (word x0 = couple x zero).
 	discriminate.
 	rewrite egal2_y; assumption.
 
-apply sym_equal; auto with v62.
+apply sym_equal; auto.
 
 intro.
 replace (injproducg V1 y) with (injgauche y).
@@ -277,15 +277,15 @@ unfold injgauche in |- *.
 intros.
 apply couple_couple_inv1 with zero zero; assumption.
 
-apply sym_equal; auto with v62.
+apply sym_equal; auto.
 
-auto with v62.
+auto.
 
-apply sym_equal; auto with v62.
+apply sym_equal; auto.
 
-auto with v62.
+auto.
 Qed.
-Hint Resolve is_mono_u_X_V1_injproducg_V1: v62.
+Hint Resolve is_mono_u_X_V1_injproducg_V1.
 
 
 Lemma is_mono_u_X_V2_injproducd_V2 : is_mono (union X V2) (injproducd V2).
@@ -298,8 +298,8 @@ replace (injproducd V2 x) with x.
 elimtype (dans y X \/ dans y V2).
 intros dans_y.
 replace (injproducd V2 y) with y.
-auto with v62.
-apply sym_equal; auto with v62.
+auto.
+apply sym_equal; auto.
 
 intros dans_y.
 replace (injproducd V2 y) with (injdroite y).
@@ -310,10 +310,10 @@ absurd (word x0 = couple y un).
 	discriminate.
 	rewrite egal_x; assumption.
 
-apply sym_equal; auto with v62.
+apply sym_equal; auto.
 
-auto with v62.
-apply sym_equal; auto with v62.
+auto.
+apply sym_equal; auto.
 
 intro dans_x.
 replace (injproducd V2 x) with (injdroite x).
@@ -327,7 +327,7 @@ absurd (word x0 = couple x un).
 	discriminate.
 	rewrite egal2_y; assumption.
 
-apply sym_equal; auto with v62.
+apply sym_equal; auto.
 
 intro.
 replace (injproducd V2 y) with (injdroite y).
@@ -335,15 +335,15 @@ unfold injdroite in |- *.
 intros.
 apply couple_couple_inv1 with un un; assumption.
 
-apply sym_equal; auto with v62.
+apply sym_equal; auto.
 
-auto with v62.
+auto.
 
-apply sym_equal; auto with v62.
+apply sym_equal; auto.
 
-auto with v62.
+auto.
 Qed.
-Hint Resolve is_mono_u_X_V2_injproducd_V2: v62.
+Hint Resolve is_mono_u_X_V2_injproducd_V2.
 
 
 
@@ -352,17 +352,17 @@ pattern X at 2 in |- *.
 replace X with X1'.
 unfold X1', V1', R1', S1', GGG1, GG1, G1 in |- *.
 apply egal_LG.
-auto with v62.
-auto with v62.
-red in |- *; auto with v62.
+auto.
+auto.
+red in |- *; auto.
 
 unfold X1' in |- *; simpl in |- *.
 apply map_Id.
 red in |- *.
-auto with v62.
+auto.
 
 Qed.
-Hint Resolve egal_LG_1_1': v62.
+Hint Resolve egal_LG_1_1'.
 
 
 Lemma egal_LG_2_2' : l_egal (LG X V2 R2 S2) (LG X V2' R2' S2').
@@ -371,17 +371,17 @@ replace X with X2'.
 
 unfold X2', V2', R2', S2', GGG2, GG2, G2 in |- *.
 apply egal_LG.
-auto with v62.
-auto with v62.
-red in |- *; auto with v62.
+auto.
+auto.
+red in |- *; auto.
 
 unfold X2' in |- *; simpl in |- *.
 apply map_Id.
 red in |- *.
-auto with v62.
+auto.
 
 Qed.
-Hint Resolve egal_LG_2_2': v62.
+Hint Resolve egal_LG_2_2'.
 
 
 
@@ -389,14 +389,14 @@ Lemma egal_X_X1' : X1' = X :>Ensf.
 unfold X1' in |- *. simpl in |- *.
 apply map_Id.
 red in |- *.
-auto with v62.
+auto.
 Qed.
 
 Lemma egal_X_X2' : X2' = X :>Ensf.
 unfold X2' in |- *. simpl in |- *.
 apply map_Id.
 red in |- *.
-auto with v62.
+auto.
 Qed.
 
 
@@ -404,38 +404,38 @@ Lemma Grammaire1' : isGram X V1' R1' S1'.
 rewrite <- egal_X_X1'.
 unfold X1', V1', R1', S1', GGG1, GG1, G1 in |- *.
 apply image_isGram.
-	auto with v62.
+	auto.
 
 	change (Mots X1') in |- *.
 	rewrite egal_X_X1'.
-	auto with v62.
+	auto.
 
-	apply inter_Xim_Vim_empty; auto with v62.
+	apply inter_Xim_Vim_empty; auto.
 
 Qed.
-Hint Resolve Grammaire1': v62.
+Hint Resolve Grammaire1'.
 
 
 Lemma Grammaire2' : isGram X V2' R2' S2'.
 rewrite <- egal_X_X2'.
 unfold X2', V2', R2', S2', GGG2, GG2, G2 in |- *.
 apply image_isGram.
-	auto with v62.
+	auto.
 
 	change (Mots X2') in |- *.
 	rewrite egal_X_X2'.
-	auto with v62.
+	auto.
 
-	apply inter_Xim_Vim_empty; auto with v62.
+	apply inter_Xim_Vim_empty; auto.
 
 Qed.
-Hint Resolve Grammaire2': v62.
+Hint Resolve Grammaire2'.
 
 Lemma inter_V1'_V2'_empty : inter V1' V2' empty.
 unfold V1', V2' in |- *; simpl in |- *.
 unfold inter in |- *.
-split; [ auto with v62 | split ].
-auto with v62.
+split; [ auto | split ].
+auto.
 
 replace (map (injproducg V1) V1) with (map injgauche V1).
 replace (map (injproducd V2) V2) with (map injdroite V2).
@@ -450,19 +450,19 @@ red in |- *.
 intro.
 cut (0 = 1 :>nat).
 change (0 <> 1 :>nat) in |- *.
-auto with v62.
+auto.
 change (natural_inv (natural 0) = natural_inv (natural 1) :>nat) in |- *.
 apply (f_equal natural_inv); assumption.
 apply couple_couple_inv2 with x1 x2.
 replace (couple x1 zero) with x.
-auto with v62.
+auto.
 apply dans_map; assumption.
 apply dans_map; assumption.
-auto with v62.
-auto with v62.
+auto.
+auto.
 Qed.
 
-Hint Resolve inter_V1'_V2'_empty: v62.
+Hint Resolve inter_V1'_V2'_empty.
 
 
 
@@ -470,14 +470,14 @@ Lemma egal_LG_u_1'_2' :
  l_egal (LG X Vu Ru S') (lunion (LG X V1' R1' S1') (LG X V2' R2' S2')).
 unfold Ru, Vu, C', Gim in |- *.
 apply Gunion_disj_LG.
-auto with v62.
-auto with v62.
-auto with v62.
-auto with v62.
-auto with v62.
-auto with v62.
+auto.
+auto.
+auto.
+auto.
+auto.
+auto.
 Qed.
-Hint Resolve egal_LG_u_1'_2': v62.
+Hint Resolve egal_LG_u_1'_2'.
 
 
 
@@ -515,13 +515,13 @@ change
   (l_egal (LG X Vu Ru S') (lunion (LG X V1' R1' S1') (LG X V2' R2' S2')))
  in |- *.
 
-auto with v62.
+auto.
 
 change (l_egal (LG X V2 R2 S2) (LG X V2' R2' S2')) in |- *.
-auto with v62.
+auto.
 
 change (l_egal (LG X V1 R1 S1) (LG X V1' R1' S1')) in |- *.
-auto with v62.
+auto.
 
 Qed.
 

--- a/gram_aut.v
+++ b/gram_aut.v
@@ -86,16 +86,16 @@ unfold f_R_d in |- *.
 intros dans_y_R eg_x_f_y.
 exists (cons (first y) nil).
 apply inmonoid_cons.
-trivial with v62.
+trivial.
 elim (Regles_X_V_R y dans_y_R).
 intros f_y dans_f_y_V temp; elim temp; clear temp.
 intros u eg_y inmono_u.
 rewrite eg_y.
 unfold first in |- *.
 unfold P in |- *.
-auto with v62.
+auto.
 exists (eps X).
-auto with v62.
+auto.
 exists (word_inv (second y)).
 elim (Regles_X_V_R y dans_y_R).
 intros f_y dans_f_y_V temp; elim temp; clear temp.
@@ -126,20 +126,20 @@ unfold f_X_d in |- *.
 intros dans_y_X eg_x_f_y.
 exists (cons y nil).
 apply inmonoid_cons.
-trivial with v62.
+trivial.
 unfold P in |- *.
-auto with v62.
+auto.
 
 exists y.
-auto with v62.
+auto.
 exists nil.
-trivial with v62.
+trivial.
 assumption.
 
 apply dans_map.
 assumption.
 
-auto with v62.
+auto.
 Qed.
 
 
@@ -148,7 +148,7 @@ red in |- *.
 split.
 unfold wd in |- *.
 apply inmonoid_cons.
-trivial with v62.
+trivial.
 unfold P in |- *.
 apply union_d.
 apply isGram3 with X R.
@@ -173,7 +173,7 @@ apply Word_rec.
 
 exists nil.
 exists nil.
-auto with v62.
+auto.
 
 intros x w Hyp.
 elim Hyp.
@@ -190,16 +190,16 @@ apply inmonoid_cons; assumption.
 split.
 unfold Append in |- *.
 simpl in |- *.
-auto with v62.
+auto.
 
 elim spec_or; intro; assumption.
 intro N_dans_x_X.
 exists nil.
 exists (cons x w).
 split.
-auto with v62.
+auto.
 split.
-auto with v62.
+auto.
 apply or_intror.
 exists x.
 assumption.
@@ -244,7 +244,7 @@ replace a' with (Append a' nil).
 generalize x; clear x; simple induction x.
 
 intro temp; elim temp.
-auto with v62.
+auto.
 
 intros x0 w Hyp temp; elim temp; clear temp.
 intros a_eg b'_eg.
@@ -274,7 +274,7 @@ replace a with (Append a nil).
 generalize x; clear x; simple induction x.
 
 intro temp; elim temp.
-auto with v62.
+auto.
 
 intros x0 w Hyp temp; elim temp; clear temp.
 intros a'_eg b_eg.
@@ -309,7 +309,7 @@ unfold cut1, cut in |- *.
 elim (cut_spec w).
 intros a temp; elim temp; clear temp.
 intros b temp; elim temp; clear temp.
-simpl in |- *; auto with v62.
+simpl in |- *; auto.
 Qed.
 
 Lemma cut_Append : forall w : Word, w = Append (cut1 w) (cut2 w).
@@ -319,7 +319,7 @@ elim (cut_spec w).
 intros a temp; elim temp; clear temp.
 intros b temp; elim temp; clear temp.
 intros inm temp; elim temp.
-simpl in |- *; auto with v62.
+simpl in |- *; auto.
 Qed.
 
 Lemma cut1_cons :
@@ -353,7 +353,7 @@ absurd (cons a w = nil).
 discriminate.
 rewrite <- b'_nil.
 rewrite <- App_nil_b'_eg_cons_a_w.
-trivial with v62.
+trivial.
 intro temp; elim temp; clear temp.
 intros x0 N_dans_x0_X temp; elim temp; clear temp.
 intros w1 eg_b'_cons.
@@ -377,7 +377,7 @@ apply cons_cons_inv2 with x0 a.
 assumption.
 assumption.
 
-split; auto with v62.
+split; auto.
 assumption.
 assumption.
 Qed.
@@ -387,24 +387,24 @@ Lemma cut1_Append :
  forall u v : Word, inmonoid X u -> cut1 (Append u v) = Append u (cut1 v).
 intros u v.
 generalize u; clear u; simple induction u.
-auto with v62.
+auto.
 intros x w Hyp inmon_x_w.
 replace (cut1 (Append (cons x w) v)) with (cons x (cut1 (Append w v))).
 replace (Append (cons x w) (cut1 v)) with (cons x (Append w (cut1 v))).
 apply cons_cons.
-trivial with v62.
+trivial.
 
 apply Hyp.
 apply inmonoid_cons_inv with x; assumption.
 
-trivial with v62.
+trivial.
 
 apply sym_equal.
 unfold Append in |- *.
 simpl in |- *.
 apply cut1_cons.
 apply inmonoid_cons_inv2 with w.
-trivial with v62.
+trivial.
 Qed.
 
 
@@ -426,7 +426,7 @@ cut (inmonoid X a).
 cut (Append a b = cons A v).
 clear App_eg inmon_a.
 generalize a; clear a; simple induction a.
-	auto with v62.
+	auto.
 
 	intros x w Hyp App_eg_x_w inmon.
 	absurd (dans A X).
@@ -451,7 +451,7 @@ elim Der.
 intros.
 replace (cut1 (cons A v)) with nil.
 exists (Append u v).
-trivial with v62.
+trivial.
 replace (cut2 (cons A v)) with (cons A v).
 apply Deriveg1.
 assumption.
@@ -480,7 +480,7 @@ cut (Append a b = cons A v). (***)(*pour l'induction*)
 clear App_eg inmon_a p.
 generalize a; clear a; simple induction a.
 
-auto with v62.
+auto.
 
 intros x0 w Hyp App inmon.
 absurd (dans A X).
@@ -513,7 +513,7 @@ exists w.
 replace (cut1 (cons x0 u)) with (cons x0 (cut1 u)).
 unfold Append in |- *.
 simpl in |- *.
-apply cons_cons; trivial with v62.
+apply cons_cons; trivial.
 
 apply sym_equal.
 apply cut1_cons.
@@ -541,13 +541,13 @@ elimtype (u = nil \/ (exists w : Word, (exists x : Elt, u = cons x w))).
 intros u_eg.
 exists (Append u0 v0).
 rewrite u_eg.
-trivial with v62.
+trivial.
 replace v with (cons A v0).
 apply Deriveg1; assumption.
 replace v with (Append u v).
-auto with v62.
+auto.
 rewrite u_eg.
-trivial with v62.
+trivial.
 intro temp; elim temp; clear temp.
 intros w temp; elim temp; clear temp.
 intros x0 u_eg inmon_u.
@@ -565,18 +565,18 @@ assumption.
 apply cons_cons_inv1 with v0 (Append w v).
 change (cons A v0 = Append (cons x0 w) v) in |- *.
 rewrite <- u_eg.
-auto with v62.
+auto.
 
 clear eg_App.
 generalize u; clear u; simple induction u.
 
-auto with v62.
+auto.
 
 intros x0 w hyp.
 apply or_intror.
 exists w.
 exists x0.
-trivial with v62.
+trivial.
 
 intros u0 v0 x0 dans_x0_X Derg_u_v Hyp u v.
 elimtype (u = nil \/ (exists w : Word, (exists x : Elt, u = cons x w))).
@@ -584,7 +584,7 @@ intro eg_u.
 rewrite eg_u.
 intros App_eg inmon_nil.
 exists (cons x0 v0).
-trivial with v62.
+trivial.
 replace v with (cons x0 u0).
 apply Deriveg2.
 assumption.
@@ -611,12 +611,12 @@ apply inmonoid_cons_inv with x1.
 assumption.
 
 generalize u; clear u; simple induction u.
-auto with v62.
+auto.
 intros x2 w hyp.
 apply or_intror.
 exists w.
 exists x2.
-trivial with v62.
+trivial.
 
 Qed.
 
@@ -687,14 +687,14 @@ unfold Derive_P_A_2_nind in |- *.
 elim Der.
 intros w u x0 dans_x0_X.
 apply or_introl.
-exists x0; auto with v62.
+exists x0; auto.
 
 intros v w u x0 dans_couple_Der.
 apply or_intror.
 exists x0.
 exists w.
-auto with v62.
-exists u; auto with v62.
+auto.
+exists u; auto.
 Qed.
 
 
@@ -727,17 +727,17 @@ intros x0 dans_x0_X temp; elim temp; clear temp.
 intros eg_cons_x_x0 eg_v_cons.
 exists (snd z).
 replace x with x0.
-trivial with v62.
+trivial.
 apply cons_cons_inv1 with (fst z) u.
-auto with v62.
+auto.
 unfold Derivestar_P_A_2 in |- *.
 replace u with (fst z).
 cut (Rstar (Word * Word) Derive_P_A_2 z (nil, nil)).
 elim z.
-auto with v62.
+auto.
 assumption.
 apply cons_cons_inv2 with x0 x.
-auto with v62.
+auto.
 
 simpl in |- *.
 intros x0 temp; elim temp; clear temp; intros w eg temp; elim temp;
@@ -747,9 +747,9 @@ absurd (dans x0 V).
 apply inter_dans with X.
 exact (isGram2 X V R S' Gram).
 replace x0 with x.
-trivial with v62.
+trivial.
 apply cons_cons_inv1 with u w.
-auto with v62.
+auto.
 apply Regles_inv1 with X R (word u0).
 exact Regles_X_V_R.
 assumption.
@@ -775,8 +775,8 @@ elimtype (u = nil \/ (exists w : Word, (exists x : Elt, u = cons x w))).
 intros u_eg.
 rewrite u_eg.
 intros App_eg inmon_nil.
-exists y; auto with v62.
-replace v with nil; trivial with v62.
+exists y; auto.
+replace v with nil; trivial.
 
 intro temp; elim temp; clear temp; intros w temp; elim temp; clear temp.
 intros x0 eg_u.
@@ -784,22 +784,22 @@ rewrite eg_u.
 intros cons_eg_nil.
 absurd (cons x0 (Append w v) = nil).
 discriminate.
-trivial with v62.
+trivial.
 
 generalize u; clear u; simple induction u.
-auto with v62.
-intros x1 w1 Hyp; apply or_intror; exists w1; exists x1; trivial with v62.
+auto.
+intros x1 w1 Hyp; apply or_intror; exists w1; exists x1; trivial.
 
 intros x0 w Hyp y Der_star_cons u v App_eg inmon_X.
 elimtype (u = nil \/ (exists w : Word, (exists x : Elt, u = cons x w))).
 intros u_eg.
 rewrite u_eg.
 replace v with (cons x0 w).
-exists y; trivial with v62.
+exists y; trivial.
 replace v with (Append u v).
-auto with v62.
+auto.
 rewrite u_eg.
-trivial with v62.
+trivial.
 
 intro temp; elim temp; clear temp; intros w1 temp; elim temp; clear temp.
 intros x1 eg_u.
@@ -819,35 +819,35 @@ apply cons_cons.
 apply cons_cons_inv1 with (Append w1 v) w.
 rewrite <- App_eg.
 rewrite eg_u.
-trivial with v62.
-trivial with v62.
-trivial with v62.
-trivial with v62.
+trivial.
+trivial.
+trivial.
+trivial.
 
 apply Hyp.
-trivial with v62.
+trivial.
 apply cons_cons_inv2 with x1 x0.
 rewrite <- App_eg.
 rewrite eg_u.
-trivial with v62.
+trivial.
 apply inmonoid_cons_inv with x1.
 rewrite <- eg_u.
-trivial with v62.
+trivial.
 apply Der_cons_inv.
 replace x0 with x1.
 apply inmonoid_cons_inv2 with w1.
 rewrite <- eg_u.
-trivial with v62.
+trivial.
 apply cons_cons_inv1 with (Append w1 v) w.
 rewrite <- App_eg.
 rewrite eg_u.
-trivial with v62.
+trivial.
 assumption.
 
 clear inmon_X App_eg.
 generalize u; clear u; simple induction u.
-auto with v62.
-intros x1 w1 tmp; apply or_intror; exists w1; exists x1; trivial with v62.
+auto.
+intros x1 w1 tmp; apply or_intror; exists w1; exists x1; trivial.
 
 Qed.
 
@@ -863,9 +863,9 @@ elimtype
  (ex2 (fun w : Word => Append (cons u nil) w = y)
     (fun w : Word => Derivestar_P_A_2 (x, w) (nil, nil))).
 intros w eg_App Der.
-exists w; trivial with v62.
+exists w; trivial.
 
-apply Derive_P_A_2_imp_Der_P_A_2_App with (cons u x); auto with v62.
+apply Derive_P_A_2_imp_Der_P_A_2_App with (cons u x); auto.
 Qed.
 
 
@@ -883,7 +883,7 @@ apply inmonoid_cons_inv2 with w; assumption.
 apply Hyp.
 apply inmonoid_cons_inv with x0; assumption.
 Qed.
-Hint Resolve Derivestar_P_A_2_x: v62.
+Hint Resolve Derivestar_P_A_2_x.
 
 
 Lemma Derivegstar_imp_Derivestar_P_A_2 :
@@ -893,7 +893,7 @@ unfold Derivegstar, Rstar in |- *.
 intros x y Der_star.
 pattern x, y in |- *.
 apply Der_star.
-auto with v62.
+auto.
 
 intros u v w Derg_u_v.
 generalize w.
@@ -917,7 +917,7 @@ apply Rstar_R with (u0, x1).
 apply Derive_X.
 assumption.
 apply Hyp1.
-auto with v62.
+auto.
 apply inmonoid_cons_inv with x0.
 rewrite <- w0_eg_cons.
 assumption.
@@ -926,7 +926,7 @@ apply Der_cons_inv.
 assumption.
 exact (Hyp2 inmon_w0).
 Qed.
-Hint Resolve Derivegstar_imp_Derivestar_P_A_2: v62.
+Hint Resolve Derivegstar_imp_Derivestar_P_A_2.
 
 
 (*equivalence de Derive_P_A_2 et Derive_P_A*)
@@ -947,8 +947,8 @@ apply union_d.
 change (dans (f_X_d x0) (map f_X_d X)) in |- *.
 apply dans_map_inv.
 assumption.
-trivial with v62.
-trivial with v62.
+trivial.
+trivial.
 
 intros v w u x0 dans_couple.
 replace (cons x0 w) with (Append (cons x0 nil) w).
@@ -960,10 +960,10 @@ replace (couple (word (cons x0 nil)) (couple (eps X) (word u))) with
 apply dans_map_inv.
 assumption.
 unfold f_R_d in |- *.
-trivial with v62.
-trivial with v62.
+trivial.
+trivial.
 Qed.
-Hint Resolve Derive_P_A_2_imp_Derive_P_A: v62.
+Hint Resolve Derive_P_A_2_imp_Derive_P_A.
 
 Lemma Derivestar_P_A_2_imp_Derivestar_P_A :
  forall x y : Word * Word, Derivestar_P_A_2 x y -> Derivestar_P_A X d x y.
@@ -974,9 +974,9 @@ apply Rstar_Der.
 intros.
 apply Rstar_reflexive.
 intros u v w Hyp1 Hyp2.
-apply Rstar_R with v; auto with v62.
+apply Rstar_R with v; auto.
 Qed.
-Hint Resolve Derivestar_P_A_2_imp_Derivestar_P_A: v62.
+Hint Resolve Derivestar_P_A_2_imp_Derivestar_P_A.
 
 
 (*seconde implication*)
@@ -1020,23 +1020,23 @@ replace (Append nil w) with w.
 replace (Append (cons x0 nil) w) with (cons x0 w).
 apply Derive_X.
 assumption.
-trivial with v62.
-trivial with v62.
+trivial.
+trivial.
 apply word_word_inv.
 apply couple_couple_inv2 with r x0.
 apply couple_couple_inv2 with (word (cons r nil)) (word w1).
-auto with v62.
+auto.
 replace x0 with r.
 apply word_word_inv.
 apply couple_couple_inv1 with (couple r (word nil)) (couple x0 (word w2)).
-auto with v62.
+auto.
 apply couple_couple_inv1 with (word nil) (word w2).
 apply couple_couple_inv2 with (word (cons r nil)) (word w1).
-auto with v62.
+auto.
 
 apply dans_map.
 assumption.
-auto with v62.
+auto.
 
 unfold d in |- *.
 intros w w1 w2 u dans_couple_d.
@@ -1064,20 +1064,20 @@ replace (first (couple A (word B))) with A.
 replace (second (couple A (word B))) with (word B).
 rewrite <- eg_r.
 assumption.
-trivial with v62.
-trivial with v62.
+trivial.
+trivial.
 
 apply Regles_X_V_R.
 assumption.
 apply couple_couple_inv2 with (eps X) (eps X).
 apply couple_couple_inv2 with (word (cons (first r) nil)) (word w1).
-auto with v62.
-trivial with v62.
+auto.
+trivial.
 apply word_word_inv.
 apply
  couple_couple_inv1
   with (couple (eps X) (second r)) (couple (eps X) (word w2)).
-auto with v62.
+auto.
 apply dans_map.
 assumption.
 
@@ -1092,12 +1092,12 @@ replace (eps X) with r.
 assumption.
 apply couple_couple_inv1 with (word nil) (word w2).
 apply couple_couple_inv2 with (word (cons r nil)) (word w1).
-auto with v62.
+auto.
 apply dans_map.
 assumption.
-auto with v62.
+auto.
 Qed.
-Hint Resolve Derive_P_A_imp_Derive_P_A_2: v62.
+Hint Resolve Derive_P_A_imp_Derive_P_A_2.
 
 
 Lemma Derivestar_P_A_imp_Derivestar_P_A_2 :
@@ -1109,10 +1109,10 @@ apply Der_star.
 intros.
 apply Rstar_reflexive.
 intros u v w Deri_u_v Rstar_v_w.
-apply Rstar_R with v; auto with v62.
+apply Rstar_R with v; auto.
 Qed.
 
-Hint Resolve Derivestar_P_A_imp_Derivestar_P_A_2: v62.
+Hint Resolve Derivestar_P_A_imp_Derivestar_P_A_2.
 
 
 
@@ -1124,7 +1124,7 @@ Theorem Derivestar_imp_Derivestar_P_A :
  forall x y : Word,
  Derivestar R x y -> inmonoid X y -> Derivestar_P_A X d (x, y) (nil, nil).
 
-auto with v62.
+auto.
 Qed.
 (**************************************************************)
 
@@ -1156,8 +1156,8 @@ change
 
 elim Derive_P_A_3_s1_v1_s2_v2; simpl in |- *.
 intros w u s x dans_x_X.
-replace (cons x u) with (Append (cons x nil) u); trivial with v62.
-auto with v62.
+replace (cons x u) with (Append (cons x nil) u); trivial.
+auto.
 Qed.
 
 
@@ -1173,7 +1173,7 @@ change
      (s1, (u1, v1)) (s2, (u2, v2))) in |- *.
 
 apply Derivestar_P_A_3_s1_v1_s2_v2.
-trivial with v62.
+trivial.
 intros u v w.
 elim u. intros uu1 uuc. elim uuc. intros uu2 uu3.
 elim v. intros vv1 vvc. elim vvc. intros vv2 vv3.
@@ -1217,7 +1217,7 @@ intros s1 Der_3_s_u_s1_v.
 elim (Ex_v_w s1).
 intros s2 Rstar_s1_v_s2_w.
 exists s2.
-apply Rstar_R with (s1, v); trivial with v62.
+apply Rstar_R with (s1, v); trivial.
 apply Derive_P_A_2_imp_Derive_P_A_3; assumption.
 Qed.
 
@@ -1227,7 +1227,7 @@ Lemma Deriveg_imp_Deriveg_App_2 :
  inmonoid X a -> Deriveg X R x y -> Deriveg X R (Append a x) (Append a y).
 intros x y.
 simple induction a.
-auto with v62.
+auto.
 
 intros x0 w Hyp inmonoid_X_cons_x0_w Der_x_y.
 change (Deriveg X R (cons x0 (Append w x)) (cons x0 (Append w y))) in |- *.
@@ -1257,7 +1257,7 @@ intros w u s0 x0 dans_x0_X inmon_s.
 replace (Append (Append s0 (cons x0 nil)) w) with
  (Append s0 (Append (cons x0 nil) w)).
 apply Rstar_reflexive.
-auto with v62.
+auto.
 
 intros v w u s0 x0 dans_couple_x0_u_R inmon_s.
 apply Rstar_R with (Append s0 (Append u w)).
@@ -1279,8 +1279,8 @@ change
 
 elim Der; simpl in |- *.
 intros.
-apply inmonoid_Append; auto with v62.
-auto with v62.
+apply inmonoid_Append; auto.
+auto.
 Qed.
 
 
@@ -1331,19 +1331,19 @@ replace x with (Append nil x).
 replace y with (Append s2 nil).
 apply Derivestar_P_A_3_imp_Derivegstar with y nil.
 assumption.
-trivial with v62.
+trivial.
 replace y with (Append nil y).
 apply sym_equal.
 apply Derisvestar_P_A_3_conserve with x nil.
 assumption.
-trivial with v62.
-trivial with v62.
+trivial.
+trivial.
 
 apply Derivestar_P_A_2_imp_Derivestar_P_A_3.
-auto with v62.
+auto.
 Qed.
 
-Hint Resolve Derivestar_P_A_imp_Derivestar: v62.
+Hint Resolve Derivestar_P_A_imp_Derivestar.
 
 
 
@@ -1356,9 +1356,9 @@ red in |- *.
 unfold l_inclus, LA, LG in |- *.
 split.
 intros w temp; elim temp; intros Der inmon.
-auto with v62.
+auto.
 intros w temp; elim temp; intros Der inmon.
-auto with v62.
+auto.
 Qed.
 
 

--- a/gram_g.v
+++ b/gram_g.v
@@ -52,8 +52,8 @@ Inductive Deriveg (X R : Ensf) : Word -> Word -> Prop :=
       forall (u v : Word) (x : Elt),
       dans x X -> Deriveg X R u v -> Deriveg X R (cons x u) (cons x v).
 
-Hint Resolve Deriveg1: v62.
-Hint Resolve Deriveg2: v62.
+Hint Resolve Deriveg1.
+Hint Resolve Deriveg2.
 
 
 Definition Derivegstar (X R : Ensf) := Rstar Word (Deriveg X R).
@@ -63,9 +63,9 @@ Lemma Deriveg_Derive :
 intros X R u v Der_g.
 elim Der_g.
 intros.
-apply Derive1; auto with v62.
+apply Derive1; auto.
 intros.
-apply Derive2; auto with v62.
+apply Derive2; auto.
 Qed.
 
 Lemma Derivegstar_Derivestar :
@@ -88,4 +88,4 @@ Axiom
   Derivestar_Derivegstar :
     forall (X R : Ensf) (u v : Word), Derivestar R u v -> Derivegstar X R u v.
 
-Hint Resolve Derivestar_Derivegstar: v62.
+Hint Resolve Derivestar_Derivegstar.

--- a/more_words.v
+++ b/more_words.v
@@ -41,28 +41,28 @@
 Require Import Ensf.
 Require Import Words.
 
-Hint Unfold eqwordset : v62.
+Hint Unfold eqwordset .
 
 Definition l_inclus (l1 l2 : wordset) : Prop := forall w : Word, l1 w -> l2 w.
 
-Hint Unfold l_inclus: v62.
+Hint Unfold l_inclus.
 
 Lemma refl_l_inclus : forall l1 : wordset, l_inclus l1 l1.
-auto with v62.
+auto.
 Qed.
-Hint Resolve refl_l_inclus: v62.
+Hint Resolve refl_l_inclus.
 
 Lemma trans_l_inclus :
  forall l1 l2 l3 : wordset,
  l_inclus l1 l2 -> l_inclus l2 l3 -> l_inclus l1 l3.
-auto with v62.
+auto.
 Qed.
 
 
 Definition l_egal (l1 l2 : wordset) : Prop :=
   l_inclus l1 l2 /\ l_inclus l2 l1.
 
-Hint Unfold l_egal: v62.
+Hint Unfold l_egal.
 
 (*predicat equivalent a eqwordset*)
 (*demonstration :                *)
@@ -72,16 +72,16 @@ Lemma equiv_l_egal_eqwordset :
 intros a b.
 unfold iff in |- *.
 split.
-intro Hyp; elim Hyp; auto with v62.
+intro Hyp; elim Hyp; auto.
 intros Hyp.
-split; unfold l_inclus in |- *; intro w; elim (Hyp w); auto with v62.
+split; unfold l_inclus in |- *; intro w; elim (Hyp w); auto.
 Qed.
 
 
 Lemma refl_l_egal : forall l1 : wordset, l_egal l1 l1.
-auto with v62.
+auto.
 Qed.
-Hint Resolve refl_l_egal: v62.
+Hint Resolve refl_l_egal.
 
 
 
@@ -102,7 +102,7 @@ Lemma wef_append :
 intros u v.
 elim u.
 
-	trivial with v62.
+	trivial.
 
 	unfold wef in |- *.
 	intros x w H.
@@ -116,7 +116,7 @@ Qed.
 Lemma wef_nil : forall a : Word, wef a = nil -> a = nil.
 intro a.
 case a.
-auto with v62.
+auto.
 
 unfold wef in |- *; simpl in |- *; intros x w H; discriminate H.
 
@@ -137,19 +137,19 @@ case b.
 	simpl in |- *; intros x w H.
 	exists x.
 	exists w.
-		trivial with v62.
-		injection H; auto with v62.
+		trivial.
+		injection H; auto.
 
 Qed.
 
 End more_about_words.
 
-Hint Resolve wef_cons: v62.
+Hint Resolve wef_cons.
 
 Lemma Append_assoc :
  forall a b c : Word, Append a (Append b c) = Append (Append a b) c.
 intros a b c. 
 unfold Append in |- *.
-elim a; auto with v62.
+elim a; auto.
 Qed.
-Hint Resolve Append_assoc: v62.
+Hint Resolve Append_assoc.

--- a/need.v
+++ b/need.v
@@ -65,4 +65,4 @@ Axiom
     forall (X : Ensf) (a b : Word), inmonoid X (Append a b) -> inmonoid X b.
 
 
-Hint Resolve dans_add: v62.
+Hint Resolve dans_add.


### PR DESCRIPTION
This was as simple as:

```
$ for f in *.v; do sed -e "s/with v62//g" $f > ${f}_new; mv ${f}_new $f; done
$ for f in *.v; do sed -e "s/: v62//g" $f > ${f}_new; mv ${f}_new $f; done
```

and fixing two instances where `auto with v62` had to be replaced instead by `auto with arith`.

If it is generally as simple as this, maybe it would make sense to do such operations on all the contribs, so as to remove the need for v62 in the code of 8.6.
